### PR TITLE
Add specific branch monitoring for repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "wp-autoplugin/hub2wp",
-    "description": "Browse, install, and update WordPress plugins from GitHub, as if they were in the .org repo.",
+    "version": "1.3.0",
+    "description": "Browse, install, and update WordPress themes and plugins from GitHub, as if they were in the .org repo.",
     "type": "wordpress-plugin",
     "autoload": {
         "classmap": [

--- a/hub2wp.php
+++ b/hub2wp.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: hub2wp
  * Description: Browse, install, and update WordPress plugins directly from GitHub repositories.
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: Balázs Piller
  * Text Domain: hub2wp
  * Domain Path: /languages
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'H2WP_VERSION', '1.2.0' );
+define( 'H2WP_VERSION', '1.3.0' );
 define( 'H2WP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'H2WP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'H2WP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/includes/class-h2wp-admin-ajax.php
+++ b/includes/class-h2wp-admin-ajax.php
@@ -40,6 +40,26 @@ class H2WP_Admin_Ajax {
 	}
 
 	/**
+	 * Resolve monitored branch for a repo, if configured.
+	 *
+	 * @param string $owner     Repository owner.
+	 * @param string $repo      Repository name.
+	 * @param string $repo_type Repository type.
+	 * @return string
+	 */
+	private function get_monitored_branch( $owner, $repo, $repo_type = 'plugin' ) {
+		$option_name = ( 'theme' === $repo_type ) ? 'h2wp_themes' : 'h2wp_plugins';
+		$monitored   = get_option( $option_name, array() );
+		$repo_key    = $owner . '/' . $repo;
+
+		if ( isset( $monitored[ $repo_key ]['branch'] ) ) {
+			return (string) $monitored[ $repo_key ]['branch'];
+		}
+
+		return '';
+	}
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -75,6 +95,7 @@ class H2WP_Admin_Ajax {
 		// Get access token from settings.
 		$access_token = H2WP_Settings::get_access_token();
 		$api          = new H2WP_GitHub_API( $access_token );
+		$branch       = $this->get_monitored_branch( $owner, $repo, $repo_type );
 
 		// Fetch data.
 		$repo_details = $api->get_repo_details( $owner, $repo );
@@ -82,7 +103,7 @@ class H2WP_Admin_Ajax {
 			wp_send_json_error( array( 'message' => $repo_details->get_error_message() ) );
 		}
 
-		$readme_html = $api->get_readme_html( $owner, $repo );
+		$readme_html = $api->get_readme_html( $owner, $repo, $branch );
 		if ( is_wp_error( $readme_html ) ) {
 			$readme_html = __( 'No README available.', 'hub2wp' );
 		}
@@ -103,9 +124,9 @@ class H2WP_Admin_Ajax {
 			);
 		}
 
-		// Let's try to use the pushed_at date of the default_branch
-		if ( isset( $repo_details['default_branch'] ) ) {
-			$branch_details = $api->get_branch_details( $owner, $repo, $repo_details['default_branch'] );
+		$branch_for_updated_at = ! empty( $branch ) ? $branch : ( isset( $repo_details['default_branch'] ) ? $repo_details['default_branch'] : '' );
+		if ( ! empty( $branch_for_updated_at ) ) {
+			$branch_details = $api->get_branch_details( $owner, $repo, $branch_for_updated_at );
 			if ( ! is_wp_error( $branch_details ) && isset( $branch_details['commit']['commit']['author']['date'] ) ) {
 				$last_updated = sprintf(
 					/* translators: %s: human-readable time difference */
@@ -215,14 +236,15 @@ class H2WP_Admin_Ajax {
 		ob_start();
 
 		// Check if plugin is compatible.
-		$api = new H2WP_GitHub_API( H2WP_Settings::get_access_token() );
-		$compatibility = $api->check_compatibility( $owner, $repo, $repo_type );
+		$api          = new H2WP_GitHub_API( H2WP_Settings::get_access_token() );
+		$branch       = $this->get_monitored_branch( $owner, $repo, $repo_type );
+		$compatibility = $api->check_compatibility( $owner, $repo, $repo_type, $branch );
 		if ( ! $compatibility['is_compatible'] ) {
 			$this->clean_ajax_buffers( 0 );
 			wp_send_json_error( array( 'message' => $compatibility['reason'] ) );
 		}
 
-		$download_url = $api->get_download_url( $owner, $repo );
+		$download_url = $api->get_download_url( $owner, $repo, $branch );
 
 		// Install the plugin. Pass the access token so private-repo zips can be
 		// downloaded with an Authorization header (the upgrader's built-in
@@ -319,9 +341,10 @@ class H2WP_Admin_Ajax {
 		// Get access token from settings.
 		$access_token = H2WP_Settings::get_access_token();
 		$api          = new H2WP_GitHub_API( $access_token );
+		$branch       = $this->get_monitored_branch( $owner, $repo, $repo_type );
 
 		// Check compatibility.
-		$compatibility = $api->check_compatibility( $owner, $repo, $repo_type );
+		$compatibility = $api->check_compatibility( $owner, $repo, $repo_type, $branch );
 
 		wp_send_json_success( array( 'is_compatible' => $compatibility['is_compatible'], 'reason' => $compatibility['reason'], 'headers' => ! empty( $compatibility['headers'] ) ? $compatibility['headers'] : array() ) );
 	}

--- a/includes/class-h2wp-github-api.php
+++ b/includes/class-h2wp-github-api.php
@@ -265,16 +265,20 @@ class H2WP_GitHub_API {
 	 *
 	 * @param string $owner Owner of the repo.
 	 * @param string $repo  Repo name.
+	 * @param string $branch Optional branch name.
 	 * @return string|WP_Error Rendered README HTML or error.
 	 */
-	public function get_readme_html( $owner, $repo ) {
-		$cache_key = 'readme_html_' . $owner . '_' . $repo;
+	public function get_readme_html( $owner, $repo, $branch = '' ) {
+		$cache_key = 'readme_html_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $branch );
 		$cached    = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
 		}
 
-		$url     = $this->base_url . '/repos/' . $owner . '/' . $repo . '/readme';
+		$url = $this->base_url . '/repos/' . $owner . '/' . $repo . '/readme';
+		if ( ! empty( $branch ) ) {
+			$url = add_query_arg( 'ref', $branch, $url );
+		}
 		$args    = array(
 			'headers' => array(
 				'Accept' => 'application/vnd.github.v3.html',
@@ -495,18 +499,19 @@ class H2WP_GitHub_API {
 	 * @param string $owner Owner of the repo.
 	 * @param string $repo  Repo name.
 	 * @param string $repo_type Repository type: plugin|theme.
+	 * @param string $branch Optional branch name.
 	 * @return array Compatibility data (is_compatible, reason) or error.
 	 */
-	public function check_compatibility( $owner, $repo, $repo_type = 'plugin' ) {
+	public function check_compatibility( $owner, $repo, $repo_type = 'plugin', $branch = '' ) {
 		$repo_type = in_array( $repo_type, array( 'plugin', 'theme' ), true ) ? $repo_type : 'plugin';
-		$cache_key = 'compatibility_' . $repo_type . '_' . $owner . '_' . $repo;
+		$cache_key = 'compatibility_' . $repo_type . '_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $branch );
 		$cached = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
 		}
 
 		if ( 'theme' === $repo_type ) {
-			$style_content = $this->fetch_theme_style_content( $owner, $repo );
+			$style_content = $this->fetch_theme_style_content( $owner, $repo, $branch );
 			if ( is_wp_error( $style_content ) ) {
 				$error_data = array(
 					'is_compatible' => false,
@@ -517,7 +522,7 @@ class H2WP_GitHub_API {
 			}
 			$headers = $this->extract_headers_from_style( $style_content );
 		} else {
-			$readme_content = $this->fetch_readme_content( $owner, $repo );
+			$readme_content = $this->fetch_readme_content( $owner, $repo, $branch );
 			if ( is_wp_error( $readme_content ) ) {
 				$error_data = array(
 					'is_compatible' => false,
@@ -550,13 +555,17 @@ class H2WP_GitHub_API {
 	 *
 	 * @param string $owner Owner of the repo.
 	 * @param string $repo  Repo name.
+	 * @param string $branch Optional branch name.
 	 * @return string|WP_Error Readme content or error.
 	 */
-	private function fetch_readme_content( $owner, $repo ) {
+	private function fetch_readme_content( $owner, $repo, $branch = '' ) {
 		$filenames = array( 'readme.txt', 'README.txt' );
 
 		foreach ( $filenames as $filename ) {
 			$url = $this->base_url . "/repos/{$owner}/{$repo}/contents/{$filename}";
+			if ( ! empty( $branch ) ) {
+				$url = add_query_arg( 'ref', $branch, $url );
+			}
 			$response = $this->request( $url );
 
 			if ( ! is_wp_error( $response ) ) {
@@ -574,6 +583,9 @@ class H2WP_GitHub_API {
 
 		// Fall back to the readme endpoint which will find README.md/readme.md/README etc.
 		$url = $this->base_url . "/repos/{$owner}/{$repo}/readme";
+		if ( ! empty( $branch ) ) {
+			$url = add_query_arg( 'ref', $branch, $url );
+		}
 		$response = $this->request( $url );
 
 		if ( ! is_wp_error( $response ) ) {
@@ -592,13 +604,17 @@ class H2WP_GitHub_API {
 	 *
 	 * @param string $owner Owner of the repo.
 	 * @param string $repo  Repo name.
+	 * @param string $branch Optional branch name.
 	 * @return string|WP_Error Theme style.css content or error.
 	 */
-	private function fetch_theme_style_content( $owner, $repo ) {
+	private function fetch_theme_style_content( $owner, $repo, $branch = '' ) {
 		$filenames = array( 'style.css', 'STYLE.CSS' );
 
 		foreach ( $filenames as $filename ) {
 			$url      = $this->base_url . "/repos/{$owner}/{$repo}/contents/{$filename}";
+			if ( ! empty( $branch ) ) {
+				$url = add_query_arg( 'ref', $branch, $url );
+			}
 			$response = $this->request( $url );
 
 			if ( ! is_wp_error( $response ) ) {
@@ -726,16 +742,17 @@ class H2WP_GitHub_API {
 	 *
 	 * @param string $owner Owner of the repo.
 	 * @param string $repo  Repo name.
+	 * @param string $branch Optional branch name.
 	 * @return array|WP_Error Parsed headers or error.
 	 */
-	public function get_readme_headers( $owner, $repo ) {
-		$cache_key = 'readme_headers_' . $owner . '_' . $repo;
+	public function get_readme_headers( $owner, $repo, $branch = '' ) {
+		$cache_key = 'readme_headers_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $branch );
 		$cached = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
 		}
 
-		$readme_content = $this->fetch_readme_content( $owner, $repo );
+		$readme_content = $this->fetch_readme_content( $owner, $repo, $branch );
 		if ( is_wp_error( $readme_content ) ) {
 			return $readme_content;
 		}
@@ -750,16 +767,17 @@ class H2WP_GitHub_API {
 	 *
 	 * @param string $owner Owner of the repo.
 	 * @param string $repo  Repo name.
+	 * @param string $branch Optional branch name.
 	 * @return array|WP_Error Parsed headers or error.
 	 */
-	public function get_theme_headers( $owner, $repo ) {
-		$cache_key = 'theme_headers_' . $owner . '_' . $repo;
+	public function get_theme_headers( $owner, $repo, $branch = '' ) {
+		$cache_key = 'theme_headers_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $branch );
 		$cached    = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
 		}
 
-		$style_content = $this->fetch_theme_style_content( $owner, $repo );
+		$style_content = $this->fetch_theme_style_content( $owner, $repo, $branch );
 		if ( is_wp_error( $style_content ) ) {
 			return $style_content;
 		}
@@ -767,6 +785,20 @@ class H2WP_GitHub_API {
 		$headers = $this->extract_headers_from_style( $style_content );
 		H2WP_Cache::set( $cache_key, $headers );
 		return $headers;
+	}
+
+	/**
+	 * Build a stable cache-key segment for a branch.
+	 *
+	 * @param string $branch Branch name.
+	 * @return string
+	 */
+	private function get_branch_cache_key_segment( $branch ) {
+		if ( empty( $branch ) ) {
+			return 'default';
+		}
+
+		return 'branch_' . md5( $branch );
 	}
 
 	/**

--- a/includes/class-h2wp-github-api.php
+++ b/includes/class-h2wp-github-api.php
@@ -84,15 +84,19 @@ class H2WP_GitHub_API {
 	}
 
 	/**
-	 * Get zipball URL for the main branch of a repository.
+	 * Get zipball URL for a repository.
 	 *
-	 * @param string $owner Owner of the repo.
-	 * @param string $repo  Repo name.
+	 * @param string $owner  Owner of the repo.
+	 * @param string $repo   Repo name.
+	 * @param string $branch Optional branch name.
 	 * @return string Zipball URL.
 	 */
-	public function get_download_url( $owner, $repo ) {
-		$branch_url = $this->base_url . '/repos/' . $owner . '/' . $repo . '/zipball';
-		return $branch_url;
+	public function get_download_url( $owner, $repo, $branch = '' ) {
+		$url = $this->base_url . '/repos/' . $owner . '/' . $repo . '/zipball';
+		if ( ! empty( $branch ) ) {
+			$url .= '/' . $branch;
+		}
+		return $url;
 	}
 
 	/**

--- a/includes/class-h2wp-plugin-updater.php
+++ b/includes/class-h2wp-plugin-updater.php
@@ -67,9 +67,10 @@ class H2WP_Plugin_Updater {
 
 		foreach ( $h2wp_plugins as $plugin_id => &$plugin ) {
 			list( $owner, $repo ) = explode( '/', $plugin_id );
+			$branch = isset( $plugin['branch'] ) ? $plugin['branch'] : '';
 
 			// Get readme headers
-			$headers = $api->get_readme_headers( $owner, $repo );
+			$headers = $api->get_readme_headers( $owner, $repo, $branch );
 			if ( is_wp_error( $headers ) || empty( $headers['stable tag'] ) ) {
 				if ( is_wp_error( $headers ) ) {
 					self::log_debug( sprintf( 'Plugin update check failed for %s: %s', $plugin_id, $headers->get_error_message() ) );
@@ -83,7 +84,6 @@ class H2WP_Plugin_Updater {
 			$plugin['tested']       = isset( $headers['tested up to'] ) ? $headers['tested up to'] : '';
 			$plugin['requires_php'] = isset( $headers['requires php'] ) ? $headers['requires php'] : '';
 			$plugin['last_checked'] = $now;
-			$branch = isset( $plugin['branch'] ) ? $plugin['branch'] : '';
 			$plugin['download_url'] = $api->get_download_url( $owner, $repo, $branch );
 
 			$plugins_updated = true;
@@ -96,8 +96,9 @@ class H2WP_Plugin_Updater {
 
 		foreach ( $h2wp_themes as $theme_id => &$theme ) {
 			list( $owner, $repo ) = explode( '/', $theme_id );
+			$branch = isset( $theme['branch'] ) ? $theme['branch'] : '';
 
-			$headers = $api->get_theme_headers( $owner, $repo );
+			$headers = $api->get_theme_headers( $owner, $repo, $branch );
 			if ( is_wp_error( $headers ) || empty( $headers['version'] ) ) {
 				if ( is_wp_error( $headers ) ) {
 					self::log_debug( sprintf( 'Theme update check failed for %s: %s', $theme_id, $headers->get_error_message() ) );
@@ -110,7 +111,6 @@ class H2WP_Plugin_Updater {
 			$theme['tested']       = isset( $headers['tested up to'] ) ? $headers['tested up to'] : '';
 			$theme['requires_php'] = isset( $headers['requires php'] ) ? $headers['requires php'] : '';
 			$theme['last_checked'] = $now;
-			$branch = isset( $theme['branch'] ) ? $theme['branch'] : '';
 			$theme['download_url'] = $api->get_download_url( $owner, $repo, $branch );
 
 			if ( empty( $theme['stylesheet'] ) ) {
@@ -273,10 +273,11 @@ class H2WP_Plugin_Updater {
 
 			if ( $plugin_slug === $args->slug ) {
 				list( $owner, $repo ) = explode( '/', $plugin_id );
+				$branch = isset( $plugin['branch'] ) ? $plugin['branch'] : '';
 
 				$api          = new H2WP_GitHub_API( H2WP_Settings::get_access_token() );
 				$repo_details = $api->get_repo_details( $owner, $repo );
-				$readme_html  = $api->get_readme_html( $owner, $repo );
+				$readme_html  = $api->get_readme_html( $owner, $repo, $branch );
 
 				if ( is_wp_error( $repo_details ) || is_wp_error( $readme_html ) ) {
 					return $result;

--- a/includes/class-h2wp-plugin-updater.php
+++ b/includes/class-h2wp-plugin-updater.php
@@ -83,7 +83,8 @@ class H2WP_Plugin_Updater {
 			$plugin['tested']       = isset( $headers['tested up to'] ) ? $headers['tested up to'] : '';
 			$plugin['requires_php'] = isset( $headers['requires php'] ) ? $headers['requires php'] : '';
 			$plugin['last_checked'] = $now;
-			$plugin['download_url'] = $api->get_download_url( $owner, $repo );
+			$branch = isset( $plugin['branch'] ) ? $plugin['branch'] : '';
+			$plugin['download_url'] = $api->get_download_url( $owner, $repo, $branch );
 
 			$plugins_updated = true;
 		}
@@ -109,7 +110,8 @@ class H2WP_Plugin_Updater {
 			$theme['tested']       = isset( $headers['tested up to'] ) ? $headers['tested up to'] : '';
 			$theme['requires_php'] = isset( $headers['requires php'] ) ? $headers['requires php'] : '';
 			$theme['last_checked'] = $now;
-			$theme['download_url'] = $api->get_download_url( $owner, $repo );
+			$branch = isset( $theme['branch'] ) ? $theme['branch'] : '';
+			$theme['download_url'] = $api->get_download_url( $owner, $repo, $branch );
 
 			if ( empty( $theme['stylesheet'] ) ) {
 				$theme['stylesheet'] = H2WP_Admin_Page::get_installed_theme_stylesheet( $owner, $repo );

--- a/includes/class-h2wp-settings.php
+++ b/includes/class-h2wp-settings.php
@@ -223,7 +223,6 @@ class H2WP_Settings {
 					<thead>
 						<tr>
 							<th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
-							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Branch', 'hub2wp' ); ?></th>
 							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
 							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
 						</tr>
@@ -237,14 +236,11 @@ class H2WP_Settings {
 									<small>
 										<a href="<?php echo esc_url( 'https://github.com/' . $repo_key ); ?>" target="_blank">
 											<?php echo esc_html( $repo_key ); ?>
-										</a>
+										</a><?php if ( ! empty( $repo_data['branch'] ) ) : ?> (<?php echo esc_html( $repo_data['branch'] ); ?>)<?php endif; ?>
 										<?php if ( ! empty( $repo_data['plugin_file'] ) ) : ?>
 											&rarr; <code><?php echo esc_html( $repo_data['plugin_file'] ); ?></code>
 										<?php endif; ?>
 									</small>
-								</td>
-								<td>
-									<code><?php echo esc_html( ! empty( $repo_data['branch'] ) ? $repo_data['branch'] : 'default' ); ?></code>
 								</td>
 								<td>
 									<?php
@@ -387,7 +383,6 @@ class H2WP_Settings {
 					<thead>
 						<tr>
 							<th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
-							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Branch', 'hub2wp' ); ?></th>
 							<th style="width:100px;max-width:100px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
 							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
 						</tr>
@@ -401,14 +396,11 @@ class H2WP_Settings {
 									<small>
 										<a href="<?php echo esc_url( 'https://github.com/' . $repo_key ); ?>" target="_blank">
 											<?php echo esc_html( $repo_key ); ?>
-										</a>
+										</a><?php if ( ! empty( $repo_data['branch'] ) ) : ?> (<?php echo esc_html( $repo_data['branch'] ); ?>)<?php endif; ?>
 										<?php if ( ! empty( $repo_data['stylesheet'] ) ) : ?>
 											&rarr; <code><?php echo esc_html( $repo_data['stylesheet'] ); ?></code>
 										<?php endif; ?>
 									</small>
-								</td>
-								<td>
-									<code><?php echo esc_html( ! empty( $repo_data['branch'] ) ? $repo_data['branch'] : 'default' ); ?></code>
 								</td>
 								<td>
 									<?php

--- a/includes/class-h2wp-settings.php
+++ b/includes/class-h2wp-settings.php
@@ -196,13 +196,21 @@ class H2WP_Settings {
 								name="h2wp_private_repo"
 								value=""
 								placeholder="owner/repo"
-								size="50"
+								size="30"
+							/>
+							<input
+								type="text"
+								id="h2wp_branch_input"
+								name="h2wp_branch"
+								value=""
+								placeholder="main (default)"
+								size="15"
 							/>
 							<button type="submit" class="button button-secondary">
 								<?php esc_html_e( 'Add Repository', 'hub2wp' ); ?>
 							</button>
 							<p class="description">
-								<?php esc_html_e( 'Enter the repository in the format: owner/repo (e.g., mycompany/private-plugin)', 'hub2wp' ); ?>
+								<?php esc_html_e( 'Enter the repository in the format: owner/repo (e.g., mycompany/private-plugin). Optional: specify a branch (defaults to repository default branch).', 'hub2wp' ); ?>
 							</p>
 						</td>
 					</tr>
@@ -215,6 +223,7 @@ class H2WP_Settings {
 					<thead>
 						<tr>
 							<th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
+							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Branch', 'hub2wp' ); ?></th>
 							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
 							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
 						</tr>
@@ -233,6 +242,9 @@ class H2WP_Settings {
 											&rarr; <code><?php echo esc_html( $repo_data['plugin_file'] ); ?></code>
 										<?php endif; ?>
 									</small>
+								</td>
+								<td>
+									<code><?php echo esc_html( ! empty( $repo_data['branch'] ) ? $repo_data['branch'] : 'default' ); ?></code>
 								</td>
 								<td>
 									<?php
@@ -348,13 +360,21 @@ class H2WP_Settings {
 								name="h2wp_private_theme_repo"
 								value=""
 								placeholder="owner/repo"
-								size="50"
+								size="30"
+							/>
+							<input
+								type="text"
+								id="h2wp_theme_branch_input"
+								name="h2wp_theme_branch"
+								value=""
+								placeholder="main (default)"
+								size="15"
 							/>
 							<button type="submit" class="button button-secondary">
 								<?php esc_html_e( 'Add Repository', 'hub2wp' ); ?>
 							</button>
 							<p class="description">
-								<?php esc_html_e( 'Enter the repository in the format: owner/repo (e.g., mycompany/private-theme)', 'hub2wp' ); ?>
+								<?php esc_html_e( 'Enter the repository in the format: owner/repo (e.g., mycompany/private-theme). Optional: specify a branch (defaults to repository default branch).', 'hub2wp' ); ?>
 							</p>
 						</td>
 					</tr>
@@ -367,6 +387,7 @@ class H2WP_Settings {
 					<thead>
 						<tr>
 							<th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
+							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Branch', 'hub2wp' ); ?></th>
 							<th style="width:100px;max-width:100px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
 							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
 						</tr>
@@ -385,6 +406,9 @@ class H2WP_Settings {
 											&rarr; <code><?php echo esc_html( $repo_data['stylesheet'] ); ?></code>
 										<?php endif; ?>
 									</small>
+								</td>
+								<td>
+									<code><?php echo esc_html( ! empty( $repo_data['branch'] ) ? $repo_data['branch'] : 'default' ); ?></code>
 								</td>
 								<td>
 									<?php
@@ -547,6 +571,7 @@ class H2WP_Settings {
 		}
 
 		$repo_input = sanitize_text_field( wp_unslash( $_POST['h2wp_private_repo'] ) );
+		$branch = isset( $_POST['h2wp_branch'] ) ? sanitize_text_field( wp_unslash( $_POST['h2wp_branch'] ) ) : '';
 
 		// Validate format: owner/repo
 		if ( ! self::validate_repo_format( $repo_input ) ) {
@@ -602,6 +627,7 @@ class H2WP_Settings {
 			'repo'             => $repo,
 			'name'             => isset( $repo_data['name'] ) ? $repo_data['name'] : $repo,
 			'private'          => isset( $repo_data['private'] ) ? $repo_data['private'] : false,
+			'branch'           => $branch,
 			'added'            => time(),
 			'added_by'         => get_current_user_id(),
 			'last_checked'     => time(),
@@ -720,6 +746,7 @@ class H2WP_Settings {
 		}
 
 		$repo_input = sanitize_text_field( wp_unslash( $_POST['h2wp_private_theme_repo'] ) );
+		$branch = isset( $_POST['h2wp_theme_branch'] ) ? sanitize_text_field( wp_unslash( $_POST['h2wp_theme_branch'] ) ) : '';
 		if ( ! self::validate_repo_format( $repo_input ) ) {
 			add_settings_error( 'h2wp_theme_repos', 'h2wp_theme_invalid_format', __( 'Invalid repository format. Please use "owner/repo" format.', 'hub2wp' ), 'error' );
 			return;
@@ -749,6 +776,7 @@ class H2WP_Settings {
 			'repo'         => $repo,
 			'name'         => isset( $repo_data['name'] ) ? $repo_data['name'] : $repo,
 			'private'      => isset( $repo_data['private'] ) ? $repo_data['private'] : false,
+			'branch'       => $branch,
 			'added'        => time(),
 			'added_by'     => get_current_user_id(),
 			'last_checked' => time(),

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ Also check out the [hub2wp Plugin Repository](https://hub2wp.com/) a public webs
 - **Caching**: Built-in caching minimizes API requests for faster performance and reduced API quota usage.
 - **Manual Update Monitoring**: Set up update monitoring for plugins and themes installed outside hub2wp.
 - **Private Repository Support**: Browse, install, and update plugins and themes from private GitHub repositories.
+- **Custom Branch Tracking**: Track a specific branch for updates instead of the repository's default branch.
 
 ---
 
@@ -30,13 +31,13 @@ Also check out the [hub2wp Plugin Repository](https://hub2wp.com/) a public webs
    To appear in hub2wp, a repository must have the `wordpress-plugin` or `wordpress-theme` GitHub topic. Plugins also need a `Stable tag:` header in their `readme.txt` or `readme.md`, and themes need a `Version:` header in `style.css`. These version headers are used for update monitoring.
 
 2. **Update Mechanism**:
-   Currently, hub2wp checks the `Stable tag:` or `Version:` header in the default branch of the repository to manage updates. In the future, support for GitHub releases will be added, prioritizing them for update monitoring if the repository uses the releases feature.
+   hub2wp checks the `Stable tag:` or `Version:` header in a repository branch to manage updates. By default it uses the repository's default branch, but you can configure a specific branch to track for each plugin or theme. When a new version is detected, you will receive an update notification in your WordPress dashboard, allowing you to update the plugin or theme directly from there.
 
 3. **Installation**:
    - Download the latest release from the [Releases](https://github.com/WP-Autoplugin/hub2wp/releases) page.
    - Upload the ZIP file via the 'Plugins' screen in WordPress or extract it to the `/wp-content/plugins/` directory.
    - Activate hub2wp from the 'Plugins' menu.
-   - Start exploring GitHub plugins under “Plugins > Add GitHub Plugin”. Themes will be available under “Appearance > Themes > GitHub Themes”.
+   - Start exploring GitHub plugins under "Plugins > Add GitHub Plugin". Browse themes by clicking on the "GitHub Themes" button under "Appearance > Themes".
 
 4. **Configuration (Optional)**:
    - Add a personal GitHub token in “Settings > GitHub Plugins” to increase API limits and access private repositories.
@@ -50,7 +51,6 @@ Also check out the [hub2wp Plugin Repository](https://hub2wp.com/) a public webs
 hub2wp will continue to evolve with the following planned features:
 
 - **Release Tracking**: Monitor GitHub releases for updates instead of just the default branch.
-- **Custom Branch Monitoring**: Enable update tracking for specific branches other than the main branch.
 - **Full WP-CLI Integration**: Provide WP-CLI commands for managing GitHub plugins via the command line.
 
 ---
@@ -111,19 +111,4 @@ hub2wp is open source and welcomes contributions. If you encounter issues or hav
 
 ## Changelog
 
-### 1.2.0
-- New: Added support for themes in addition to plugins.
-- New: Added filter link for GitHub plugins on the Plugins page.
-- Fix: Use repo name as the plugin or theme slug on installation.
-
-### 1.1.0
-- New: Added support for private GitHub repositories.
-- New: Private repositories tab in plugin browser.
-- New: Settings page UI for managing repositories / monitored plugins.
-
-### 1.0.1
-- Fix: Update plugin data saved in the activation hook.
-- Fix: Use the last commit date from the default branch as the plugin's last updated date.
-
-### 1.0.0
-- Initial release
+See [readme.txt](readme.txt) for the full changelog.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pbalazs
 Tags: github, plugins, installer
 Requires at least: 5.8
 Tested up to: 6.9
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,6 +34,9 @@ Features:
 No, but you have a higher request limit if you use one.
 
 == Changelog ==
+
+= 1.3.0 =
+* New: Added support for monitoring a specified branch for updates in addition to the default branch.
 
 = 1.2.0 =
 * New: Added support for themes in addition to plugins.


### PR DESCRIPTION
This PR adds the ability to monitor specific branches of GitHub repositories for updates.

## Features
- Optional branch field when adding monitored repositories
- Branch column displayed in monitored plugins/themes tables  
- Download URLs use branch-specific zipball endpoints
- Update checker respects branch settings
- Backward compatible - existing repos work as before

## Changes
- get_download_url() now accepts optional branch parameter
- Settings UI shows branch input with "default" placeholder
- Plugin/theme data structure includes 'branch' field
- Empty branch value falls back to repository default branch

## Use Cases
- Monitor develop branch for beta testing
- Track staging branch for pre-production
- Use feature branches for specific workflows