### PR TITLE
Support for monorepo plugins and themes (+ minor bug fixes and UI/UX updates)

### DIFF
--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -557,4 +557,186 @@ jQuery(document).ready(function($) {
         });
     }
 
+    // Monorepo Detection — intercept "Add Theme Repository" form
+    var $addThemeForm = $('input#h2wp_private_theme_repo_input').closest('form');
+    var $themeInput   = $('#h2wp_private_theme_repo_input');
+
+    if ( $addThemeForm.length && $themeInput.length ) {
+
+        $themeInput.closest('td').append('<div id="h2wp-monorepo-theme-picker" style="display:none;margin-top:12px;"></div>');
+
+        $addThemeForm.on('submit', function(e) {
+            var repoValue = $.trim( $themeInput.val() );
+            var parts     = repoValue.split('/');
+
+            if ( parts.length !== 2 || !parts[0] || !parts[1] ) {
+                return;
+            }
+
+            if ( $('#h2wp-theme-subdirectory-ready').val() === '1' ) {
+                return;
+            }
+
+            e.preventDefault();
+
+            var owner   = parts[0];
+            var repo    = parts[1];
+            var $btn    = $addThemeForm.find('button[type="submit"]');
+            var $picker = $('#h2wp-monorepo-theme-picker');
+
+            $btn.prop('disabled', true);
+            var detectInterval = h2wpStartDotAnimation( $btn, 'Detecting All Themes' );
+            $picker.hide().empty();
+
+            $.ajax({
+                url: h2wp_ajax_object.ajax_url,
+                method: 'POST',
+                data: {
+                    action:    'h2wp_detect_repo_type',
+                    nonce:     h2wp_ajax_object.nonce,
+                    owner:     owner,
+                    repo:      repo,
+                    repo_type: 'theme'
+                },
+                success: function(response) {
+                    if ( !response.success ) {
+                        alert( response.data.message || 'Could not detect repository type.' );
+                        return;
+                    }
+                    if ( 'single' === response.data.type ) {
+                        $addThemeForm.off('submit').submit();
+                        return;
+                    }
+                    h2wpRenderMonorepoThemePicker( response.data.plugins, owner, repo );
+                },
+                error: function() {
+                    alert( h2wp_ajax_object.error_message || 'An error occurred.' );
+                },
+                complete: function() {
+                    clearInterval( detectInterval );
+                    $btn.prop('disabled', false).text('Add Repository');
+                }
+            });
+        });
+    }
+
+    function h2wpRenderMonorepoThemePicker( themes, owner, repo ) {
+        var $picker = $('#h2wp-monorepo-theme-picker');
+        var monitoredThemeSubdirs = h2wp_ajax_object.monitored_theme_subdirs || [];
+
+        var html  = '<p><strong>Theme monorepo detected</strong> — ';
+            html += themes.length + ' theme(s) found. Select which to monitor:</p>';
+            html += '<label style="display:block;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid #ddd;">';
+            html += '<input type="checkbox" id="h2wp-select-all-themes" checked /> <strong>Select All / Deselect All</strong>';
+            html += '</label>';
+            html += '<div id="h2wp-theme-checklist" style="margin:0 0 12px;">';
+
+        var availableCount = 0;
+        themes.forEach(function(theme) {
+            var monitored = monitoredThemeSubdirs.indexOf( theme.subdirectory ) !== -1;
+            if ( monitored ) {
+                html += '<label style="display:block;margin-bottom:6px;opacity:0.55;cursor:default;">'
+                    + '<input type="checkbox" class="h2wp-monorepo-theme-cb" value="' + theme.subdirectory + '" disabled /> '
+                    + '<strong>' + theme.slug + '</strong> '
+                    + '<span style="color:#646970;font-size:12px;">(' + theme.subdirectory + ')</span>'
+                    + ' <em style="color:#2271b1;font-size:12px;">— Already Monitoring</em>'
+                    + '</label>';
+            } else {
+                availableCount++;
+                html += '<label style="display:block;margin-bottom:6px;">'
+                    + '<input type="checkbox" class="h2wp-monorepo-theme-cb" value="' + theme.subdirectory + '" checked /> '
+                    + '<strong>' + theme.slug + '</strong> '
+                    + '<span style="color:#646970;font-size:12px;">(' + theme.subdirectory + ')</span>'
+                    + '</label>';
+            }
+        });
+
+        html += '</div>';
+        html += '<button type="button" id="h2wp-add-selected-themes" class="button button-primary">Add Selected Themes (' + availableCount + ')</button> ';
+        html += '<button type="button" id="h2wp-cancel-theme-picker" class="button">Cancel</button>';
+        html += '<div id="h2wp-add-theme-status" style="margin-top:10px;"></div>';
+
+        $picker.html(html).show();
+
+        $('#h2wp-select-all-themes').on('change', function() {
+            $('.h2wp-monorepo-theme-cb:not(:disabled)').prop('checked', $(this).is(':checked'));
+            var checked = $('.h2wp-monorepo-theme-cb:not(:disabled):checked').length;
+            $('#h2wp-add-selected-themes').text( 'Add Selected Themes (' + checked + ')' );
+        });
+
+        $(document).on('change', '.h2wp-monorepo-theme-cb:not(:disabled)', function() {
+            var total   = $('.h2wp-monorepo-theme-cb:not(:disabled)').length;
+            var checked = $('.h2wp-monorepo-theme-cb:not(:disabled):checked').length;
+            $('#h2wp-select-all-themes').prop('checked', total === checked)
+                                        .prop('indeterminate', checked > 0 && checked < total);
+            $('#h2wp-add-selected-themes').text( 'Add Selected Themes (' + checked + ')' );
+        });
+
+        $('#h2wp-cancel-theme-picker').on('click', function() {
+            $picker.hide().empty();
+        });
+
+        $('#h2wp-add-selected-themes').on('click', function() {
+            var selected = [];
+            $('.h2wp-monorepo-theme-cb:not(:disabled):checked').each(function() {
+                selected.push( $(this).val() );
+            });
+            if ( !selected.length ) {
+                alert('Please select at least one theme.');
+                return;
+            }
+            var $btn      = $(this);
+            var $status   = $('#h2wp-add-theme-status');
+            var branch    = $.trim( $('#h2wp_theme_branch_input').val() );
+            var prioritize = $('#h2wp_theme_prioritize_releases').is(':checked') ? '1' : '0';
+
+            $btn.prop('disabled', true);
+            var addInterval = h2wpStartDotAnimation( $btn, 'Adding Selected Themes' );
+            $status.empty();
+
+            h2wpAddThemesSequentially( selected, 0, owner, repo, branch, prioritize, $btn, $status, 0, addInterval );
+        });
+    }
+
+    function h2wpAddThemesSequentially( subdirs, index, owner, repo, branch, prioritize, $btn, $status, successCount, dotInterval ) {
+        if ( index >= subdirs.length ) {
+            if ( dotInterval ) { clearInterval( dotInterval ); }
+            var base = window.location.href.split('&h2wp_added=')[0];
+            window.location.href = base + '&h2wp_added=' + successCount;
+            return;
+        }
+
+        var subdirectory = subdirs[ index ];
+        var slug         = subdirectory.split('/').pop();
+
+        $.ajax({
+            url: h2wp_ajax_object.ajax_url,
+            method: 'POST',
+            data: {
+                action:              'h2wp_add_monitored_repo',
+                nonce:               h2wp_ajax_object.nonce,
+                owner:               owner,
+                repo:                repo,
+                branch:              branch,
+                prioritize_releases: prioritize,
+                subdirectory:        subdirectory,
+                repo_type:           'theme'
+            },
+            success: function(response) {
+                if ( response.success ) {
+                    $status.append('<p style="color:#00a32a;">&#10003; Added: <strong>' + slug + '</strong></p>');
+                    successCount++;
+                } else {
+                    $status.append('<p style="color:#d63638;">&#10007; ' + slug + ': ' + ( response.data.message || 'Unknown error' ) + '</p>');
+                }
+            },
+            error: function() {
+                $status.append('<p style="color:#d63638;">&#10007; Error adding <strong>' + slug + '</strong></p>');
+            },
+            complete: function() {
+                h2wpAddThemesSequentially( subdirs, index + 1, owner, repo, branch, prioritize, $btn, $status, successCount, dotInterval );
+            }
+        });
+    }
+
 });

--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -444,16 +444,29 @@ jQuery(document).ready(function($) {
             html += '</label>';
             html += '<div id="h2wp-plugin-checklist" style="margin:0 0 12px;">';
 
+        var availableCount = 0;
         plugins.forEach(function(plugin) {
-            html += '<label style="display:block;margin-bottom:6px;">'
-                + '<input type="checkbox" class="h2wp-monorepo-plugin-cb" value="' + plugin.subdirectory + '" checked /> '
-                + '<strong>' + plugin.slug + '</strong> '
-                + '<span style="color:#646970;font-size:12px;">(' + plugin.subdirectory + ')</span>'
-                + '</label>';
+            var monitored = h2wp_ajax_object.monitored_subdirs &&
+                            h2wp_ajax_object.monitored_subdirs.indexOf( plugin.subdirectory ) !== -1;
+            if ( monitored ) {
+                html += '<label style="display:block;margin-bottom:6px;opacity:0.55;cursor:default;">'
+                    + '<input type="checkbox" class="h2wp-monorepo-plugin-cb" value="' + plugin.subdirectory + '" disabled /> '
+                    + '<strong>' + plugin.slug + '</strong> '
+                    + '<span style="color:#646970;font-size:12px;">(' + plugin.subdirectory + ')</span>'
+                    + ' <em style="color:#2271b1;font-size:12px;">— Already Monitoring</em>'
+                    + '</label>';
+            } else {
+                availableCount++;
+                html += '<label style="display:block;margin-bottom:6px;">'
+                    + '<input type="checkbox" class="h2wp-monorepo-plugin-cb" value="' + plugin.subdirectory + '" checked /> '
+                    + '<strong>' + plugin.slug + '</strong> '
+                    + '<span style="color:#646970;font-size:12px;">(' + plugin.subdirectory + ')</span>'
+                    + '</label>';
+            }
         });
 
         html += '</div>';
-        html += '<button type="button" id="h2wp-add-selected-plugins" class="button button-primary">Add Selected Plugins (' + plugins.length + ')</button> ';
+        html += '<button type="button" id="h2wp-add-selected-plugins" class="button button-primary">Add Selected Plugins (' + availableCount + ')</button> ';
         html += '<button type="button" id="h2wp-cancel-picker" class="button">Cancel</button>';
         html += '<div id="h2wp-add-repo-status" style="margin-top:10px;"></div>';
 
@@ -461,15 +474,15 @@ jQuery(document).ready(function($) {
 
         // Select all / deselect all toggle
         $('#h2wp-select-all-plugins').on('change', function() {
-            $('.h2wp-monorepo-plugin-cb').prop('checked', $(this).is(':checked'));
-            var checked = $('.h2wp-monorepo-plugin-cb:checked').length;
+            $('.h2wp-monorepo-plugin-cb:not(:disabled)').prop('checked', $(this).is(':checked'));
+            var checked = $('.h2wp-monorepo-plugin-cb:not(:disabled):checked').length;
             $('#h2wp-add-selected-plugins').text( 'Add Selected Plugins (' + checked + ')' );
         });
 
         // Keep "select all" in sync when individual boxes are changed
-        $(document).on('change', '.h2wp-monorepo-plugin-cb', function() {
-            var total   = $('.h2wp-monorepo-plugin-cb').length;
-            var checked = $('.h2wp-monorepo-plugin-cb:checked').length;
+        $(document).on('change', '.h2wp-monorepo-plugin-cb:not(:disabled)', function() {
+            var total   = $('.h2wp-monorepo-plugin-cb:not(:disabled)').length;
+            var checked = $('.h2wp-monorepo-plugin-cb:not(:disabled):checked').length;
             $('#h2wp-select-all-plugins').prop('checked', total === checked)
                                         .prop('indeterminate', checked > 0 && checked < total);
             $('#h2wp-add-selected-plugins').text( 'Add Selected Plugins (' + checked + ')' );

--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -355,8 +355,17 @@ jQuery(document).ready(function($) {
         openRepositoryDetails(owner, repo, repoType, false);
     }());
 
-    // Monorepo Detection — intercept "Add Repository" form
+    // Ellipsis text animation to show the user the action is still working
+    function h2wpStartDotAnimation( $el, baseText ) {
+        var dots = 1;
+        $el.text( baseText + '.' );
+        return setInterval( function() {
+            dots = ( dots % 3 ) + 1;
+            $el.text( baseText + new Array( dots + 1 ).join( '.' ) );
+        }, 500 );
+    }
 
+    // Monorepo Detection — intercept "Add Repository" form
     var $addRepoForm = $('input#h2wp_private_repo_input').closest('form');
     var $repoInput   = $('#h2wp_private_repo_input');
 
@@ -386,7 +395,8 @@ jQuery(document).ready(function($) {
             var $btn    = $addRepoForm.find('button[type="submit"]');
             var $picker = $('#h2wp-monorepo-picker');
 
-            $btn.prop('disabled', true).text('Detecting...');
+            $btn.prop('disabled', true);
+            var detectInterval = h2wpStartDotAnimation( $btn, 'Detecting All Plugins' );
             $picker.hide().empty();
 
             $.ajax({
@@ -417,6 +427,7 @@ jQuery(document).ready(function($) {
                     alert( h2wp_ajax_object.error_message || 'An error occurred.' );
                 },
                 complete: function() {
+                    clearInterval( detectInterval );
                     $btn.prop('disabled', false).text('Add Repository');
                 }
             });
@@ -429,7 +440,7 @@ jQuery(document).ready(function($) {
         var html  = '<p><strong>Monorepo detected</strong> — ';
             html += plugins.length + ' plugin(s) found. Select which to monitor:</p>';
             html += '<label style="display:block;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid #ddd;">';
-            html += '<input type="checkbox" id="h2wp-select-all-plugins" checked /> <strong>Select all / Deselect all</strong>';
+            html += '<input type="checkbox" id="h2wp-select-all-plugins" checked /> <strong>Select All / Deselect All</strong>';
             html += '</label>';
             html += '<div id="h2wp-plugin-checklist" style="margin:0 0 12px;">';
 
@@ -442,7 +453,7 @@ jQuery(document).ready(function($) {
         });
 
         html += '</div>';
-        html += '<button type="button" id="h2wp-add-selected-plugins" class="button button-primary">Add Selected Plugins</button> ';
+        html += '<button type="button" id="h2wp-add-selected-plugins" class="button button-primary">Add Selected Plugins (' + plugins.length + ')</button> ';
         html += '<button type="button" id="h2wp-cancel-picker" class="button">Cancel</button>';
         html += '<div id="h2wp-add-repo-status" style="margin-top:10px;"></div>';
 
@@ -451,6 +462,8 @@ jQuery(document).ready(function($) {
         // Select all / deselect all toggle
         $('#h2wp-select-all-plugins').on('change', function() {
             $('.h2wp-monorepo-plugin-cb').prop('checked', $(this).is(':checked'));
+            var checked = $('.h2wp-monorepo-plugin-cb:checked').length;
+            $('#h2wp-add-selected-plugins').text( 'Add Selected Plugins (' + checked + ')' );
         });
 
         // Keep "select all" in sync when individual boxes are changed
@@ -459,6 +472,7 @@ jQuery(document).ready(function($) {
             var checked = $('.h2wp-monorepo-plugin-cb:checked').length;
             $('#h2wp-select-all-plugins').prop('checked', total === checked)
                                         .prop('indeterminate', checked > 0 && checked < total);
+            $('#h2wp-add-selected-plugins').text( 'Add Selected Plugins (' + checked + ')' );
         });
 
         $('#h2wp-cancel-picker').on('click', function() {
@@ -481,15 +495,17 @@ jQuery(document).ready(function($) {
             var branch    = $.trim( $('#h2wp_branch_input').val() );
             var prioritize = $('#h2wp_prioritize_releases').is(':checked') ? '1' : '0';
 
-            $btn.prop('disabled', true).text('Adding...');
+            $btn.prop('disabled', true);
+            var addInterval = h2wpStartDotAnimation( $btn, 'Adding Selected Plugins' );
             $status.empty();
 
-            h2wpAddPluginsSequentially( selected, 0, owner, repo, branch, prioritize, $btn, $status, 0 );
+            h2wpAddPluginsSequentially( selected, 0, owner, repo, branch, prioritize, $btn, $status, 0, addInterval );
         });
     }
 
-    function h2wpAddPluginsSequentially( subdirs, index, owner, repo, branch, prioritize, $btn, $status, successCount ) {
+    function h2wpAddPluginsSequentially( subdirs, index, owner, repo, branch, prioritize, $btn, $status, successCount, dotInterval ) {
         if ( index >= subdirs.length ) {
+            if ( dotInterval ) { clearInterval( dotInterval ); }
             // Auto-redirect back to this page with a success param for the WP notice
             var base = window.location.href.split('&h2wp_added=')[0];
             window.location.href = base + '&h2wp_added=' + successCount;
@@ -523,7 +539,7 @@ jQuery(document).ready(function($) {
                 $status.append('<p style="color:#d63638;">&#10007; Error adding <strong>' + slug + '</strong></p>');
             },
             complete: function() {
-                h2wpAddPluginsSequentially( subdirs, index + 1, owner, repo, branch, prioritize, $btn, $status, successCount );
+                h2wpAddPluginsSequentially( subdirs, index + 1, owner, repo, branch, prioritize, $btn, $status, successCount, dotInterval );
             }
         });
     }

--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -248,12 +248,15 @@ jQuery(document).ready(function($) {
             return;
         }
 
+        var subdirectory = button.data('subdirectory') || '';
+
         var pluginData = {
             action: 'h2wp_install_plugin',
             nonce: h2wp_ajax_object.nonce,
             owner: owner,
             repo: repo,
-            repo_type: repoType
+            repo_type: repoType,
+            subdirectory: subdirectory
         };
 
         // Make AJAX request to install plugin.
@@ -351,4 +354,178 @@ jQuery(document).ready(function($) {
 
         openRepositoryDetails(owner, repo, repoType, false);
     }());
+
+    // Monorepo Detection — intercept "Add Repository" form
+
+    var $addRepoForm = $('input#h2wp_private_repo_input').closest('form');
+    var $repoInput   = $('#h2wp_private_repo_input');
+
+    if ( $addRepoForm.length && $repoInput.length ) {
+
+        // Inject picker container below the existing form description
+        $repoInput.closest('td').append('<div id="h2wp-monorepo-picker" style="display:none;margin-top:12px;"></div>');
+
+        $addRepoForm.on('submit', function(e) {
+            var repoValue = $.trim( $repoInput.val() );
+            var parts     = repoValue.split('/');
+
+            // Only intercept clean owner/repo values
+            if ( parts.length !== 2 || !parts[0] || !parts[1] ) {
+                return;
+            }
+
+            // If picker already chose a subdirectory, let the form submit normally
+            if ( $('#h2wp-subdirectory-ready').val() === '1' ) {
+                return;
+            }
+
+            e.preventDefault();
+
+            var owner   = parts[0];
+            var repo    = parts[1];
+            var $btn    = $addRepoForm.find('button[type="submit"]');
+            var $picker = $('#h2wp-monorepo-picker');
+
+            $btn.prop('disabled', true).text('Detecting...');
+            $picker.hide().empty();
+
+            $.ajax({
+                url: h2wp_ajax_object.ajax_url,
+                method: 'POST',
+                data: {
+                    action: 'h2wp_detect_repo_type',
+                    nonce:  h2wp_ajax_object.nonce,
+                    owner:  owner,
+                    repo:   repo
+                },
+                success: function(response) {
+                    if ( !response.success ) {
+                        alert( response.data.message || 'Could not detect repository type.' );
+                        return;
+                    }
+
+                    if ( 'single' === response.data.type ) {
+                        // Single repo — detach our handler and submit normally
+                        $addRepoForm.off('submit').submit();
+                        return;
+                    }
+
+                    // Monorepo — show the plugin picker
+                    h2wpRenderMonorepoPicker( response.data.plugins, owner, repo );
+                },
+                error: function() {
+                    alert( h2wp_ajax_object.error_message || 'An error occurred.' );
+                },
+                complete: function() {
+                    $btn.prop('disabled', false).text('Add Repository');
+                }
+            });
+        });
+    }
+
+    function h2wpRenderMonorepoPicker( plugins, owner, repo ) {
+        var $picker = $('#h2wp-monorepo-picker');
+
+        var html  = '<p><strong>Monorepo detected</strong> — ';
+            html += plugins.length + ' plugin(s) found. Select which to monitor:</p>';
+            html += '<label style="display:block;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid #ddd;">';
+            html += '<input type="checkbox" id="h2wp-select-all-plugins" checked /> <strong>Select all / Deselect all</strong>';
+            html += '</label>';
+            html += '<div id="h2wp-plugin-checklist" style="margin:0 0 12px;">';
+
+        plugins.forEach(function(plugin) {
+            html += '<label style="display:block;margin-bottom:6px;">'
+                + '<input type="checkbox" class="h2wp-monorepo-plugin-cb" value="' + plugin.subdirectory + '" checked /> '
+                + '<strong>' + plugin.slug + '</strong> '
+                + '<span style="color:#646970;font-size:12px;">(' + plugin.subdirectory + ')</span>'
+                + '</label>';
+        });
+
+        html += '</div>';
+        html += '<button type="button" id="h2wp-add-selected-plugins" class="button button-primary">Add Selected Plugins</button> ';
+        html += '<button type="button" id="h2wp-cancel-picker" class="button">Cancel</button>';
+        html += '<div id="h2wp-add-repo-status" style="margin-top:10px;"></div>';
+
+        $picker.html(html).show();
+
+        // Select all / deselect all toggle
+        $('#h2wp-select-all-plugins').on('change', function() {
+            $('.h2wp-monorepo-plugin-cb').prop('checked', $(this).is(':checked'));
+        });
+
+        // Keep "select all" in sync when individual boxes are changed
+        $(document).on('change', '.h2wp-monorepo-plugin-cb', function() {
+            var total   = $('.h2wp-monorepo-plugin-cb').length;
+            var checked = $('.h2wp-monorepo-plugin-cb:checked').length;
+            $('#h2wp-select-all-plugins').prop('checked', total === checked)
+                                        .prop('indeterminate', checked > 0 && checked < total);
+        });
+
+        $('#h2wp-cancel-picker').on('click', function() {
+            $picker.hide().empty();
+        });
+
+        $('#h2wp-add-selected-plugins').on('click', function() {
+            var selected = [];
+            $('.h2wp-monorepo-plugin-cb:checked').each(function() {
+                selected.push( $(this).val() );
+            });
+
+            if ( !selected.length ) {
+                alert('Please select at least one plugin.');
+                return;
+            }
+
+            var $btn      = $(this);
+            var $status   = $('#h2wp-add-repo-status');
+            var branch    = $.trim( $('#h2wp_branch_input').val() );
+            var prioritize = $('#h2wp_prioritize_releases').is(':checked') ? '1' : '0';
+
+            $btn.prop('disabled', true).text('Adding...');
+            $status.empty();
+
+            h2wpAddPluginsSequentially( selected, 0, owner, repo, branch, prioritize, $btn, $status, 0 );
+        });
+    }
+
+    function h2wpAddPluginsSequentially( subdirs, index, owner, repo, branch, prioritize, $btn, $status, successCount ) {
+        if ( index >= subdirs.length ) {
+            // Auto-redirect back to this page with a success param for the WP notice
+            var base = window.location.href.split('&h2wp_added=')[0];
+            window.location.href = base + '&h2wp_added=' + successCount;
+            return;
+        }
+
+        var subdirectory = subdirs[ index ];
+        var slug         = subdirectory.split('/').pop();
+
+        $.ajax({
+            url: h2wp_ajax_object.ajax_url,
+            method: 'POST',
+            data: {
+                action:              'h2wp_add_monitored_repo',
+                nonce:               h2wp_ajax_object.nonce,
+                owner:               owner,
+                repo:                repo,
+                branch:              branch,
+                prioritize_releases: prioritize,
+                subdirectory:        subdirectory
+            },
+            success: function(response) {
+                if ( response.success ) {
+                    $status.append('<p style="color:#00a32a;">&#10003; Added: <strong>' + slug + '</strong></p>');
+                    successCount++;
+                } else {
+                    $status.append('<p style="color:#d63638;">&#10007; ' + slug + ': ' + ( response.data.message || 'Unknown error' ) + '</p>');
+                }
+            },
+            error: function() {
+                $status.append('<p style="color:#d63638;">&#10007; Error adding <strong>' + slug + '</strong></p>');
+            },
+            complete: function() {
+                h2wpAddPluginsSequentially( subdirs, index + 1, owner, repo, branch, prioritize, $btn, $status, successCount );
+            }
+        });
+    }
+
 });

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-autoplugin/hub2wp",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "description": "Browse, install, and update WordPress themes and plugins from GitHub, as if they were in the .org repo.",
     "type": "wordpress-plugin",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-autoplugin/hub2wp",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Browse, install, and update WordPress themes and plugins from GitHub, as if they were in the .org repo.",
     "type": "wordpress-plugin",
     "autoload": {

--- a/hub2wp.php
+++ b/hub2wp.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: hub2wp
  * Description: Browse, install, and update WordPress plugins directly from GitHub repositories.
- * Version: 1.5.2
+ * Version: 1.6.0
  * Author: Balázs Piller
  * Text Domain: hub2wp
  * Domain Path: /languages
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'H2WP_VERSION', '1.5.2' );
+define( 'H2WP_VERSION', '1.6.0' );
 define( 'H2WP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'H2WP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'H2WP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/hub2wp.php
+++ b/hub2wp.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: hub2wp
  * Description: Browse, install, and update WordPress plugins directly from GitHub repositories.
- * Version: 1.6.0
+ * Version: 1.6.1
  * Author: Balázs Piller
  * Text Domain: hub2wp
  * Domain Path: /languages
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'H2WP_VERSION', '1.6.0' );
+define( 'H2WP_VERSION', '1.6.1' );
 define( 'H2WP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'H2WP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'H2WP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/includes/class-h2wp-admin-ajax.php
+++ b/includes/class-h2wp-admin-ajax.php
@@ -316,8 +316,11 @@ class H2WP_Admin_Ajax {
 			wp_send_json_error( array( 'message' => __( 'Invalid parameters.', 'hub2wp' ) ) );
 		}
 
-		$api    = new H2WP_GitHub_API( H2WP_Settings::get_access_token() );
-		$result = $api->detect_repo_type( $owner, $repo );
+		$repo_type = isset( $_POST['repo_type'] ) ? sanitize_key( wp_unslash( $_POST['repo_type'] ) ) : 'plugin';
+        $repo_type = in_array( $repo_type, array( 'plugin', 'theme' ), true ) ? $repo_type : 'plugin';
+
+        $api    = new H2WP_GitHub_API( H2WP_Settings::get_access_token() );
+        $result = $api->detect_repo_type( $owner, $repo, '', $repo_type );
 
 		if ( is_wp_error( $result ) ) {
 			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
@@ -347,7 +350,10 @@ class H2WP_Admin_Ajax {
 			wp_send_json_error( array( 'message' => __( 'Invalid parameters.', 'hub2wp' ) ) );
 		}
 
-		$result = H2WP_Settings::add_repo_to_monitored( $owner, $repo, $branch, $prioritize, $subdirectory );
+		$repo_type_for_add = isset( $_POST['repo_type'] ) ? sanitize_key( wp_unslash( $_POST['repo_type'] ) ) : 'plugin';
+        $repo_type_for_add = in_array( $repo_type_for_add, array( 'plugin', 'theme' ), true ) ? $repo_type_for_add : 'plugin';
+
+        $result = H2WP_Settings::add_repo_to_monitored( $owner, $repo, $branch, $prioritize, $subdirectory, $repo_type_for_add );
 
 		if ( is_wp_error( $result ) ) {
 			wp_send_json_error( array( 'message' => $result->get_error_message() ) );

--- a/includes/class-h2wp-admin-ajax.php
+++ b/includes/class-h2wp-admin-ajax.php
@@ -86,7 +86,9 @@ class H2WP_Admin_Ajax {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'wp_ajax_h2wp_get_plugin_details', array( $this, 'get_plugin_details' ) );
+		add_action( 'wp_ajax_h2wp_detect_repo_type', array( $this, 'detect_repo_type' ) );
+        add_action( 'wp_ajax_h2wp_add_monitored_repo', array( $this, 'add_monitored_repo' ) );
+        add_action( 'wp_ajax_h2wp_get_plugin_details', array( $this, 'get_plugin_details' ) );
 		add_action( 'wp_ajax_h2wp_check_compatibility', array( $this, 'check_compatibility' ) );
 		add_action( 'wp_ajax_h2wp_get_changelog', array( $this, 'get_changelog' ) );
 		add_action( 'wp_ajax_h2wp_install_plugin', array( $this, 'install_plugin' ) );
@@ -140,29 +142,31 @@ class H2WP_Admin_Ajax {
 		}
 
 		// Get and sanitize parameters.
-		$owner = isset( $_POST['owner'] ) ? sanitize_text_field( wp_unslash( $_POST['owner'] ) ) : '';
-		$repo  = isset( $_POST['repo'] ) ? sanitize_text_field( wp_unslash( $_POST['repo'] ) ) : '';
+        $owner        = isset( $_POST['owner'] ) ? sanitize_text_field( wp_unslash( $_POST['owner'] ) ) : '';
+        $repo         = isset( $_POST['repo'] ) ? sanitize_text_field( wp_unslash( $_POST['repo'] ) ) : '';
+        $subdirectory = isset( $_POST['subdirectory'] ) ? sanitize_text_field( wp_unslash( $_POST['subdirectory'] ) ) : '';
 
-		if ( empty( $owner ) || empty( $repo ) ) {
-			wp_send_json_error( array( 'message' => __( 'Invalid parameters.', 'hub2wp' ) ) );
-		}
+        if ( empty( $owner ) || empty( $repo ) ) {
+            wp_send_json_error( array( 'message' => __( 'Invalid parameters.', 'hub2wp' ) ) );
+        }
 
-		$buffer_level = ob_get_level();
-		ob_start();
-		$this->suspend_async_translation_updates();
+        $buffer_level = ob_get_level();
+        ob_start();
+        $this->suspend_async_translation_updates();
 
-		$tracking = $this->get_monitored_tracking_preferences( $owner, $repo, $repo_type );
+        $tracking = $this->get_monitored_tracking_preferences( $owner, $repo, $repo_type );
 
-		$result = H2WP_Repo_Manager::install_repository(
-			$owner,
-			$repo,
-			array(
-				'repo_type'           => $repo_type,
-				'branch'              => $tracking['branch'],
-				'prioritize_releases' => $tracking['prioritize_releases'],
-				'access_token'        => H2WP_Settings::get_access_token(),
-			)
-		);
+        $result = H2WP_Repo_Manager::install_repository(
+            $owner,
+            $repo,
+            array(
+                'repo_type'           => $repo_type,
+                'branch'              => $tracking['branch'],
+                'prioritize_releases' => $tracking['prioritize_releases'],
+                'access_token'        => H2WP_Settings::get_access_token(),
+                'subdirectory'        => $subdirectory,
+            )
+        );
 
 		$this->resume_async_translation_updates();
 
@@ -292,5 +296,63 @@ class H2WP_Admin_Ajax {
 		}
 
 		wp_send_json_success( array( 'changelog_html' => $service->render_changelog_html( $changelog ) ) );
+	}
+
+	/**
+	 * Detect whether a repo is a single plugin or a monorepo.
+	 * Called when the user enters a repo URL in the install UI.
+	 */
+	public function detect_repo_type() {
+		check_ajax_referer( 'h2wp_plugin_details_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'hub2wp' ) ) );
+		}
+
+		$owner = isset( $_POST['owner'] ) ? sanitize_text_field( wp_unslash( $_POST['owner'] ) ) : '';
+		$repo  = isset( $_POST['repo'] ) ? sanitize_text_field( wp_unslash( $_POST['repo'] ) ) : '';
+
+		if ( empty( $owner ) || empty( $repo ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid parameters.', 'hub2wp' ) ) );
+		}
+
+		$api    = new H2WP_GitHub_API( H2WP_Settings::get_access_token() );
+		$result = $api->detect_repo_type( $owner, $repo );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * Handle AJAX request to add a repository to the monitored list.
+	 * Supports both single repos and monorepo subdirectories.
+	 */
+	public function add_monitored_repo() {
+		check_ajax_referer( 'h2wp_plugin_details_nonce', 'nonce' );
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions.', 'hub2wp' ) ) );
+		}
+
+		$owner        = isset( $_POST['owner'] ) ? sanitize_text_field( wp_unslash( $_POST['owner'] ) ) : '';
+		$repo         = isset( $_POST['repo'] ) ? sanitize_text_field( wp_unslash( $_POST['repo'] ) ) : '';
+		$branch       = isset( $_POST['branch'] ) ? sanitize_text_field( wp_unslash( $_POST['branch'] ) ) : '';
+		$prioritize   = isset( $_POST['prioritize_releases'] ) && '1' === sanitize_text_field( wp_unslash( $_POST['prioritize_releases'] ) );
+		$subdirectory = isset( $_POST['subdirectory'] ) ? sanitize_text_field( wp_unslash( $_POST['subdirectory'] ) ) : '';
+
+		if ( empty( $owner ) || empty( $repo ) ) {
+			wp_send_json_error( array( 'message' => __( 'Invalid parameters.', 'hub2wp' ) ) );
+		}
+
+		$result = H2WP_Settings::add_repo_to_monitored( $owner, $repo, $branch, $prioritize, $subdirectory );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( array( 'message' => $result->get_error_message() ) );
+		}
+
+		wp_send_json_success( array( 'repo_key' => $result ) );
 	}
 }

--- a/includes/class-h2wp-admin-page.php
+++ b/includes/class-h2wp-admin-page.php
@@ -13,10 +13,12 @@ class H2WP_Admin_Page {
 	 */
 	public static function init() {
 		add_action( 'admin_menu', array( __CLASS__, 'add_menu_page' ) );
-		add_action( 'admin_menu', array( __CLASS__, 'add_theme_browser_page' ) );
-		add_action( 'admin_menu', array( __CLASS__, 'hide_theme_browser_submenu' ), 999 );
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
-		add_action( 'admin_footer-themes.php', array( __CLASS__, 'render_themes_screen_button' ) );
+        add_action( 'admin_menu', array( __CLASS__, 'add_theme_browser_page' ) );
+        add_action( 'admin_menu', array( __CLASS__, 'reorder_plugin_submenu' ), 9999 );
+        add_action( 'admin_menu', array( __CLASS__, 'reorder_theme_submenu' ), 9999 );
+        add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+        add_action( 'admin_footer-themes.php', array( __CLASS__, 'render_themes_screen_button' ) );
+        add_action( 'admin_footer-plugins.php', array( __CLASS__, 'render_plugins_screen_button' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'display_rate_limit_notice' ) );
 		add_filter( 'admin_title', array( __CLASS__, 'filter_admin_title' ), 10, 2 );
 		add_filter( 'plugin_action_links_' . H2WP_PLUGIN_BASENAME, array( __CLASS__, 'add_action_links' ) );
@@ -155,36 +157,116 @@ class H2WP_Admin_Page {
 	 * Add admin menu page.
 	 */
 	public static function add_menu_page() {
-		add_submenu_page(
-			'plugins.php',
-			__( 'Add Plugins', 'hub2wp' ),
-			__( 'Add GitHub Plugin', 'hub2wp' ),
-			'install_plugins',
-			'h2wp-plugin-browser',
-			array( __CLASS__, 'render_page' )
-		);
-	}
+        add_submenu_page(
+            'plugins.php',
+            __( 'Add GitHub Plugin', 'hub2wp' ),
+            __( 'Add GitHub Plugin', 'hub2wp' ),
+            'install_plugins',
+            'h2wp-plugin-browser',
+            array( __CLASS__, 'render_page' ),
+            11
+        );
+    }
 
 	/**
 	 * Register the hidden theme browser page.
 	 */
 	public static function add_theme_browser_page() {
-		add_submenu_page(
-			'themes.php',
-			__( 'GitHub Themes', 'hub2wp' ),
-			__( 'GitHub Themes', 'hub2wp' ),
-			'install_themes',
-			'h2wp-theme-browser',
-			array( __CLASS__, 'render_theme_page' )
-		);
-	}
+        add_submenu_page(
+            'themes.php',
+            __( 'Add GitHub Theme', 'hub2wp' ),
+            __( 'Add GitHub Theme', 'hub2wp' ),
+            'install_themes',
+            'h2wp-theme-browser',
+            array( __CLASS__, 'render_theme_page' )
+        );
+    }
 
 	/**
-	 * Hide the GitHub themes page from the Appearance submenu.
-	 */
-	public static function hide_theme_browser_submenu() {
-		remove_submenu_page( 'themes.php', 'h2wp-theme-browser' );
-	}
+     * Move "Add GitHub Theme" to directly above Theme File Editor in the Appearance submenu.
+     */
+    public static function reorder_theme_submenu() {
+        global $submenu;
+
+        if ( empty( $submenu['themes.php'] ) ) {
+            return;
+        }
+
+        $our_item = null;
+        $our_key  = null;
+
+        foreach ( $submenu['themes.php'] as $key => $item ) {
+            if ( isset( $item[2] ) && 'h2wp-theme-browser' === $item[2] ) {
+                $our_item = $item;
+                $our_key  = $key;
+                break;
+            }
+        }
+
+        if ( null === $our_item ) {
+            return;
+        }
+
+        unset( $submenu['themes.php'][ $our_key ] );
+
+        $reordered = array();
+        $inserted  = false;
+        foreach ( array_values( $submenu['themes.php'] ) as $item ) {
+            if ( ! $inserted && isset( $item[2] ) && 'theme-editor.php' === $item[2] ) {
+                $reordered[] = $our_item;
+                $inserted    = true;
+            }
+            $reordered[] = $item;
+        }
+        if ( ! $inserted ) {
+            $reordered[] = $our_item;
+        }
+
+        $submenu['themes.php'] = $reordered;
+    }
+
+	/**
+     * Move "Add GitHub Plugin" to directly above Plugin File Editor in the Plugins submenu.
+     */
+    public static function reorder_plugin_submenu() {
+        global $submenu;
+
+        if ( empty( $submenu['plugins.php'] ) ) {
+            return;
+        }
+
+        $our_item = null;
+        $our_key  = null;
+
+        foreach ( $submenu['plugins.php'] as $key => $item ) {
+            if ( isset( $item[2] ) && 'h2wp-plugin-browser' === $item[2] ) {
+                $our_item = $item;
+                $our_key  = $key;
+                break;
+            }
+        }
+
+        if ( null === $our_item ) {
+            return;
+        }
+
+        unset( $submenu['plugins.php'][ $our_key ] );
+
+        $reordered = array();
+        $inserted  = false;
+        foreach ( array_values( $submenu['plugins.php'] ) as $item ) {
+            if ( ! $inserted && isset( $item[2] ) && 'plugin-editor.php' === $item[2] ) {
+                $reordered[] = $our_item;
+                $inserted    = true;
+            }
+            $reordered[] = $item;
+        }
+        if ( ! $inserted ) {
+            $reordered[] = $our_item;
+        }
+
+        $submenu['plugins.php'] = $reordered;
+    }
 
 	/**
 	 * Add a "GitHub Themes" button beside "Add Theme" on Appearance > Themes.
@@ -205,12 +287,38 @@ class H2WP_Admin_Page {
 				var githubThemesButton = document.createElement('a');
 				githubThemesButton.className = 'page-title-action';
 				githubThemesButton.href = <?php echo wp_json_encode( $url ); ?>;
-				githubThemesButton.textContent = <?php echo wp_json_encode( __( 'GitHub Themes', 'hub2wp' ) ); ?>;
+				githubThemesButton.textContent = <?php echo wp_json_encode( __( 'Add GitHub Theme', 'hub2wp' ) ); ?>;
 				addThemeButton.insertAdjacentElement('afterend', githubThemesButton);
 			});
 		</script>
 		<?php
 	}
+
+	/**
+     * Add an "Add GitHub Plugin" button beside "Add New Plugin" on Plugins > Installed Plugins.
+     */
+    public static function render_plugins_screen_button() {
+        if ( ! current_user_can( 'install_plugins' ) ) {
+            return;
+        }
+
+        $url = admin_url( 'plugins.php?page=h2wp-plugin-browser' );
+        ?>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                var addPluginButton = document.querySelector('.wrap a.page-title-action');
+                if (!addPluginButton) {
+                    return;
+                }
+                var githubPluginButton = document.createElement('a');
+                githubPluginButton.className = 'page-title-action';
+                githubPluginButton.href = <?php echo wp_json_encode( $url ); ?>;
+                githubPluginButton.textContent = <?php echo wp_json_encode( __( 'Add GitHub Plugin', 'hub2wp' ) ); ?>;
+                addPluginButton.insertAdjacentElement('afterend', githubPluginButton);
+            });
+        </script>
+        <?php
+    }
 
 	/**
 	 * Check if a plugin is installed.

--- a/includes/class-h2wp-admin-page.php
+++ b/includes/class-h2wp-admin-page.php
@@ -1077,10 +1077,19 @@ class H2WP_Admin_Page {
 			wp_enqueue_script( 'h2wp-admin-scripts', H2WP_PLUGIN_URL . 'assets/js/admin-scripts.js', array( 'jquery' ), H2WP_VERSION, true );
 
 			// Localize script with AJAX URL and nonce.
+			$monitored_plugins = get_option( 'h2wp_plugins', array() );
+			$monitored_subdirs = array();
+			foreach ( $monitored_plugins as $data ) {
+				if ( ! empty( $data['subdirectory'] ) ) {
+					$monitored_subdirs[] = $data['subdirectory'];
+				}
+			}
+
 			wp_localize_script( 'h2wp-admin-scripts', 'h2wp_ajax_object', array(
-				'ajax_url'  => admin_url( 'admin-ajax.php' ),
-				'nonce'     => wp_create_nonce( 'h2wp_plugin_details_nonce' ),
-				'repo_type' => $repo_type,
+				'ajax_url'          => admin_url( 'admin-ajax.php' ),
+				'nonce'             => wp_create_nonce( 'h2wp_plugin_details_nonce' ),
+				'repo_type'         => $repo_type,
+				'monitored_subdirs' => $monitored_subdirs,
 			) );
 		}
 	}

--- a/includes/class-h2wp-admin-page.php
+++ b/includes/class-h2wp-admin-page.php
@@ -801,8 +801,10 @@ class H2WP_Admin_Page {
 	 * @param bool  $is_private Whether this is a private repository.
 	 */
 	private static function render_theme_card( $item, $is_private = false ) {
-		$name         = $item['name'];
-		$display_name = ucwords( str_replace( array( '-', 'wp', 'wordpress', 'seo' ), array( ' ', 'WP', 'WordPress', 'SEO' ), $name ) );
+        $name         = $item['name'];
+        $subdirectory = isset( $item['subdirectory'] ) ? $item['subdirectory'] : '';
+        $plugin_name  = isset( $item['plugin_name'] ) && $item['plugin_name'] ? $item['plugin_name'] : $name;
+        $display_name = ucwords( str_replace( array( '-', 'wp', 'wordpress', 'seo' ), array( ' ', 'WP', 'WordPress', 'SEO' ), $plugin_name ) );
 		$description  = isset( $item['description'] ) ? $item['description'] : '';
 		$owner        = isset( $item['owner']['login'] ) ? $item['owner']['login'] : '';
 		$avatar       = isset( $item['owner']['avatar_url'] ) ? $item['owner']['avatar_url'] : '';
@@ -821,7 +823,7 @@ class H2WP_Admin_Page {
 		echo '</div>';
 
 		echo '<div class="h2wp-theme-header">';
-		echo '<h3 class="h2wp-theme-name"><a href="' . esc_url( self::get_repo_details_url( $owner, $name, 'theme' ) ) . '" class="h2wp-theme-name-link" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="theme">' . esc_html( $display_name ) . '</a></h3>';
+		echo '<h3 class="h2wp-theme-name"><a href="' . esc_url( self::get_repo_details_url( $owner, $name, 'theme' ) ) . '" class="h2wp-theme-name-link" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="theme">' . esc_html( $display_name ) . '</a></h3>';
 		echo '<span class="h2wp-theme-author-text">' . esc_html__( 'By', 'hub2wp' ) . ' <a href="https://github.com/' . esc_attr( $owner ) . '">' . esc_html( $owner ) . '</a></span>';
 		if ( $avatar ) {
 			echo '<img src="' . esc_url( $avatar ) . '" alt="" class="h2wp-theme-author-avatar" />';
@@ -831,12 +833,12 @@ class H2WP_Admin_Page {
 
 		echo '<div class="h2wp-theme-actions">';
 		if ( self::is_repo_installed( $owner, $name, 'theme' ) ) {
-			echo '<a href="#" class="h2wp-button h2wp-button-disabled h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="theme" disabled>' . esc_html__( 'Installed', 'hub2wp' ) . '</a>';
+			echo '<a href="#" class="h2wp-button h2wp-button-disabled h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="theme" disabled>' . esc_html__( 'Installed', 'hub2wp' ) . '</a>';
 		} else {
-			echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="theme">' . esc_html__( 'Install Now', 'hub2wp' ) . '</a>';
-			echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-activate-plugin h2wp-hidden" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="theme">' . esc_html__( 'Activate', 'hub2wp' ) . '</a>';
+			echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="theme">' . esc_html__( 'Install Now', 'hub2wp' ) . '</a>';
+            echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-activate-plugin h2wp-hidden" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="theme">' . esc_html__( 'Activate', 'hub2wp' ) . '</a>';
 		}
-		echo '<a href="' . esc_url( self::get_repo_details_url( $owner, $name, 'theme' ) ) . '" class="h2wp-more-details-link" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="theme">' . esc_html__( 'More Details', 'hub2wp' ) . '</a>';
+		echo '<a href="' . esc_url( self::get_repo_details_url( $owner, $name, 'theme' ) ) . '" class="h2wp-more-details-link" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="theme">' . esc_html__( 'More Details', 'hub2wp' ) . '</a>';
 		if ( $is_private ) {
 			echo '<span class="h2wp-private-badge">' . esc_html__( 'Private', 'hub2wp' ) . '</span>';
 		}
@@ -1085,12 +1087,21 @@ class H2WP_Admin_Page {
 				}
 			}
 
-			wp_localize_script( 'h2wp-admin-scripts', 'h2wp_ajax_object', array(
-				'ajax_url'          => admin_url( 'admin-ajax.php' ),
-				'nonce'             => wp_create_nonce( 'h2wp_plugin_details_nonce' ),
-				'repo_type'         => $repo_type,
-				'monitored_subdirs' => $monitored_subdirs,
-			) );
+			$monitored_themes       = get_option( 'h2wp_themes', array() );
+            $monitored_theme_subdirs = array();
+            foreach ( $monitored_themes as $data ) {
+                if ( ! empty( $data['subdirectory'] ) ) {
+                    $monitored_theme_subdirs[] = $data['subdirectory'];
+                }
+            }
+
+            wp_localize_script( 'h2wp-admin-scripts', 'h2wp_ajax_object', array(
+                'ajax_url'               => admin_url( 'admin-ajax.php' ),
+                'nonce'                  => wp_create_nonce( 'h2wp_plugin_details_nonce' ),
+                'repo_type'              => $repo_type,
+                'monitored_subdirs'      => $monitored_subdirs,
+                'monitored_theme_subdirs' => $monitored_theme_subdirs,
+            ) );
 		}
 	}
 

--- a/includes/class-h2wp-admin-page.php
+++ b/includes/class-h2wp-admin-page.php
@@ -594,43 +594,67 @@ class H2WP_Admin_Page {
 		$items  = array();
 		$errors = array();
 
-		foreach ( $private_repos as $repo_key => $repo_data ) {
-			list( $owner, $repo ) = explode( '/', $repo_key, 2 );
+		$repo_details_cache = array(); // avoid duplicate API calls for monorepo siblings
 
-			$repo_details = $api->get_private_repo_details( $owner, $repo );
+        foreach ( $private_repos as $repo_key => $repo_data ) {
+            // Use stored owner/repo — always correct even for 3-part monorepo keys.
+            // Fall back to key-splitting only for legacy entries that lack these fields.
+            $owner        = isset( $repo_data['owner'] ) && $repo_data['owner'] ? $repo_data['owner'] : '';
+            $repo         = isset( $repo_data['repo'] )  && $repo_data['repo']  ? $repo_data['repo']  : '';
+            $subdirectory = isset( $repo_data['subdirectory'] ) ? $repo_data['subdirectory'] : '';
 
-			if ( is_wp_error( $repo_details ) ) {
-				$errors[] = array(
-					'repo'  => $repo_key,
-					'error' => $repo_details->get_error_message(),
-				);
-				continue;
-			}
+            if ( empty( $owner ) || empty( $repo ) ) {
+                $parts = explode( '/', $repo_key );
+                $owner = $parts[0];
+                $repo  = isset( $parts[1] ) ? $parts[1] : '';
+            }
 
-			// Transform API response to match search results format
-			$items[] = array(
-				'id'                => $repo_details['id'],
-				'name'              => $repo_details['name'],
-				'full_name'         => $repo_details['full_name'],
-				'description'       => isset( $repo_details['description'] ) ? $repo_details['description'] : '',
-				'owner'             => array(
-					'login'      => $repo_details['owner']['login'],
-					'avatar_url' => $repo_details['owner']['avatar_url'],
-					'html_url'   => $repo_details['owner']['html_url'],
-				),
-				'stargazers_count'  => $repo_details['stargazers_count'],
-				'forks_count'       => $repo_details['forks_count'],
-				'watchers_count'    => $repo_details['watchers_count'],
-				'open_issues_count' => $repo_details['open_issues_count'],
-				'updated_at'        => $repo_details['updated_at'],
-				'created_at'        => $repo_details['created_at'],
-				'html_url'          => $repo_details['html_url'],
-				'homepage'          => isset( $repo_details['homepage'] ) ? $repo_details['homepage'] : '',
-				'topics'            => isset( $repo_details['topics'] ) ? $repo_details['topics'] : array(),
-				'language'          => isset( $repo_details['language'] ) ? $repo_details['language'] : '',
-				'private'           => true,
-			);
-		}
+            $cache_key = $owner . '/' . $repo;
+
+            // Fetch each underlying repo only once even when multiple plugins share it
+            if ( ! isset( $repo_details_cache[ $cache_key ] ) ) {
+                $repo_details_cache[ $cache_key ] = $api->get_private_repo_details( $owner, $repo );
+            }
+            $repo_details = $repo_details_cache[ $cache_key ];
+
+            if ( is_wp_error( $repo_details ) ) {
+                $errors[] = array(
+                    'repo'  => $repo_key,
+                    'error' => $repo_details->get_error_message(),
+                );
+                continue;
+            }
+
+            // For monorepo plugins use the plugin name; otherwise use the repo name
+            $plugin_name = ! empty( $subdirectory )
+                ? ( isset( $repo_data['name'] ) && $repo_data['name'] ? $repo_data['name'] : basename( $subdirectory ) )
+                : $repo_details['name'];
+
+            $items[] = array(
+                'id'                => $repo_details['id'],
+                'name'              => $repo_details['name'],   // actual GitHub repo name (used for API calls)
+                'plugin_name'       => $plugin_name,            // display name on the card
+                'subdirectory'      => $subdirectory,           // empty string for single-repo plugins
+                'full_name'         => $repo_details['full_name'],
+                'description'       => isset( $repo_details['description'] ) ? $repo_details['description'] : '',
+                'owner'             => array(
+                    'login'      => $repo_details['owner']['login'],
+                    'avatar_url' => $repo_details['owner']['avatar_url'],
+                    'html_url'   => $repo_details['owner']['html_url'],
+                ),
+                'stargazers_count'  => $repo_details['stargazers_count'],
+                'forks_count'       => $repo_details['forks_count'],
+                'watchers_count'    => $repo_details['watchers_count'],
+                'open_issues_count' => $repo_details['open_issues_count'],
+                'updated_at'        => $repo_details['updated_at'],
+                'created_at'        => $repo_details['created_at'],
+                'html_url'          => $repo_details['html_url'],
+                'homepage'          => isset( $repo_details['homepage'] ) ? $repo_details['homepage'] : '',
+                'topics'            => isset( $repo_details['topics'] ) ? $repo_details['topics'] : array(),
+                'language'          => isset( $repo_details['language'] ) ? $repo_details['language'] : '',
+                'private'           => true,
+            );
+        }
 
 		return array(
 			'items'       => $items,
@@ -847,10 +871,12 @@ class H2WP_Admin_Page {
 	 * @param string $repo_type  Repository type.
 	 */
 	private static function render_plugin_card( $item, $is_private = false, $repo_type = 'plugin' ) {
-		$name = $item['name'];
-		$display_name = ucwords( str_replace( array( '-', 'wp', 'wordpress', 'seo' ), array( ' ', 'WP', 'WordPress', 'SEO' ), $name ) );
-		$description = isset( $item['description'] ) ? $item['description'] : '';
-		$owner = isset( $item['owner']['login'] ) ? $item['owner']['login'] : '';
+        $name         = $item['name'];
+        $subdirectory = isset( $item['subdirectory'] ) ? $item['subdirectory'] : '';
+        $plugin_name  = isset( $item['plugin_name'] ) && $item['plugin_name'] ? $item['plugin_name'] : $name;
+        $display_name = ucwords( str_replace( array( '-', 'wp', 'wordpress', 'seo' ), array( ' ', 'WP', 'WordPress', 'SEO' ), $plugin_name ) );
+        $description  = isset( $item['description'] ) ? $item['description'] : '';
+        $owner        = isset( $item['owner']['login'] ) ? $item['owner']['login'] : '';
 		$avatar = isset( $item['owner']['avatar_url'] ) ? $item['owner']['avatar_url'] : '';
 		$stars = isset( $item['stargazers_count'] ) ? number_format( $item['stargazers_count'] ) : 0;
 		$forks = isset( $item['forks_count'] ) ? number_format( $item['forks_count'] ) : 0;
@@ -861,7 +887,7 @@ class H2WP_Admin_Page {
 		echo '<div class="h2wp-plugin-icon">';
 		if ( $avatar ) {
 			// Add data attributes for AJAX.
-			echo '<img src="' . esc_url( $avatar ) . '" alt="" class="h2wp-plugin-thumbnail" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="' . esc_attr( $repo_type ) . '" style="cursor:pointer;" />';
+			echo '<img src="' . esc_url( $avatar ) . '" alt="" class="h2wp-plugin-thumbnail" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="' . esc_attr( $repo_type ) . '" style="cursor:pointer;" />';
 		} else {
 			echo '<div class="h2wp-plugin-icon-placeholder"></div>';
 		}
@@ -869,7 +895,7 @@ class H2WP_Admin_Page {
 
 		echo '<div class="h2wp-plugin-info">';
 		// Make plugin name clickable for modal.
-		echo '<h3 class="h2wp-plugin-name" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="' . esc_attr( $repo_type ) . '" style="cursor:pointer;">' . esc_html( $display_name ) . '</h3>';
+		echo '<h3 class="h2wp-plugin-name" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="' . esc_attr( $repo_type ) . '" style="cursor:pointer;">' . esc_html( $display_name ) . '</h3>';
 		echo '<div class="h2wp-plugin-author">By <a href="https://github.com/' . esc_attr( $owner ) . '">' . esc_html( $owner ) . '</a></div>';
 		
 		// Add private badge if applicable
@@ -884,14 +910,14 @@ class H2WP_Admin_Page {
 
 		echo '<div class="h2wp-plugin-actions">';
 		if ( self::is_repo_installed( $owner, $name, $repo_type ) ) {
-			echo '<a href="#" class="h2wp-button h2wp-button-disabled h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="' . esc_attr( $repo_type ) . '" disabled>' . esc_html__( 'Installed', 'hub2wp' ) . '</a>';
+			echo '<a href="#" class="h2wp-button h2wp-button-disabled h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="' . esc_attr( $repo_type ) . '" disabled>' . esc_html__( 'Installed', 'hub2wp' ) . '</a>';
 		} else {
-			echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="' . esc_attr( $repo_type ) . '">' . esc_html__( 'Install Now', 'hub2wp' ) . '</a>';
-			echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-activate-plugin h2wp-hidden" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="' . esc_attr( $repo_type ) . '">' . esc_html__( 'Activate', 'hub2wp' ) . '</a>';
+			echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-install-plugin" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="' . esc_attr( $repo_type ) . '">' . esc_html__( 'Install Now', 'hub2wp' ) . '</a>';
+            echo '<a href="#" class="h2wp-button h2wp-button-secondary h2wp-activate-plugin h2wp-hidden" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="' . esc_attr( $repo_type ) . '">' . esc_html__( 'Activate', 'hub2wp' ) . '</a>';
 		}
 
 		// Add data attributes for "More Details" link.
-		echo '<a href="' . esc_url( self::get_repo_details_url( $owner, $name, $repo_type ) ) . '" class="h2wp-more-details-link" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-type="' . esc_attr( $repo_type ) . '">' . esc_html__( 'More Details', 'hub2wp' ) . '</a>';
+		echo '<a href="' . esc_url( self::get_repo_details_url( $owner, $name, $repo_type ) ) . '" class="h2wp-more-details-link" data-owner="' . esc_attr( $owner ) . '" data-repo="' . esc_attr( $name ) . '" data-subdirectory="' . esc_attr( $subdirectory ) . '" data-type="' . esc_attr( $repo_type ) . '">' . esc_html__( 'More Details', 'hub2wp' ) . '</a>';
 		echo '</div>';
 
 		echo '<div class="h2wp-plugin-meta">';
@@ -1040,8 +1066,12 @@ class H2WP_Admin_Page {
 	 * Enqueue admin assets.
 	 */
 	public static function enqueue_assets( $hook ) {
-		if ( 'plugins_page_h2wp-plugin-browser' === $hook || 'appearance_page_h2wp-theme-browser' === $hook ) {
-			$repo_type = ( 'appearance_page_h2wp-theme-browser' === $hook ) ? 'theme' : 'plugin';
+		$is_plugin_browser = 'plugins_page_h2wp-plugin-browser' === $hook;
+		$is_theme_browser  = 'appearance_page_h2wp-theme-browser' === $hook;
+		$is_settings_page  = 'settings_page_h2wp_settings_page' === $hook;
+
+		if ( $is_plugin_browser || $is_theme_browser || $is_settings_page ) {
+			$repo_type = $is_theme_browser ? 'theme' : 'plugin';
 
 			wp_enqueue_style( 'h2wp-admin-styles', H2WP_PLUGIN_URL . 'assets/css/admin-styles.css', array(), H2WP_VERSION );
 			wp_enqueue_script( 'h2wp-admin-scripts', H2WP_PLUGIN_URL . 'assets/js/admin-scripts.js', array( 'jquery' ), H2WP_VERSION, true );
@@ -1052,8 +1082,8 @@ class H2WP_Admin_Page {
 				'nonce'     => wp_create_nonce( 'h2wp_plugin_details_nonce' ),
 				'repo_type' => $repo_type,
 			) );
-			}
 		}
+	}
 
 	/**
 	 * Display a notice if the rate limit is low.

--- a/includes/class-h2wp-github-api.php
+++ b/includes/class-h2wp-github-api.php
@@ -885,7 +885,7 @@ class H2WP_GitHub_API {
 		}
 
 		if ( 'theme' === $repo_type ) {
-			$style_content = $this->fetch_theme_style_content( $owner, $repo, $ref );
+            $style_content = $this->fetch_theme_style_content( $owner, $repo, $ref, $subdirectory );
 			if ( is_wp_error( $style_content ) ) {
 				$error_data = array(
 					'is_compatible' => false,
@@ -1006,8 +1006,17 @@ class H2WP_GitHub_API {
 	 * @param string $branch Optional branch name.
 	 * @return string|WP_Error Theme style.css content or error.
 	 */
-	private function fetch_theme_style_content( $owner, $repo, $branch = '' ) {
+	private function fetch_theme_style_content( $owner, $repo, $branch = '', $path_prefix = '' ) {
 		$filenames = array( 'style.css', 'STYLE.CSS' );
+
+		if ( ! empty( $path_prefix ) ) {
+			$filenames = array_map(
+				function( $f ) use ( $path_prefix ) {
+					return trailingslashit( $path_prefix ) . $f;
+				},
+				$filenames
+			);
+		}
 
 		foreach ( $filenames as $filename ) {
 			$url      = $this->base_url . "/repos/{$owner}/{$repo}/contents/{$filename}";
@@ -1172,16 +1181,17 @@ class H2WP_GitHub_API {
 	 * @param string $branch Optional branch name.
 	 * @return array|WP_Error Parsed headers or error.
 	 */
-	public function get_theme_headers( $owner, $repo, $branch = '', $prioritize_releases = true, $source_context = null ) {
+	public function get_theme_headers( $owner, $repo, $branch = '', $prioritize_releases = true, $source_context = null, $subdirectory = '' ) {
 		$source_context = is_array( $source_context ) ? $source_context : $this->resolve_version_source( $owner, $repo, $branch, $prioritize_releases );
 		$ref            = isset( $source_context['ref'] ) ? (string) $source_context['ref'] : $branch;
-		$cache_key      = 'theme_headers_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $ref ) . '_' . ( ! empty( $source_context['source'] ) ? $source_context['source'] : 'branch' );
+		$subdir_key     = ! empty( $subdirectory ) ? '_' . md5( $subdirectory ) : '';
+		$cache_key      = 'theme_headers_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $ref ) . '_' . ( ! empty( $source_context['source'] ) ? $source_context['source'] : 'branch' ) . $subdir_key;
 		$cached    = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
 		}
 
-		$style_content = $this->fetch_theme_style_content( $owner, $repo, $ref );
+		$style_content = $this->fetch_theme_style_content( $owner, $repo, $ref, $subdirectory );
 		if ( is_wp_error( $style_content ) ) {
 			return $style_content;
 		}
@@ -1326,8 +1336,9 @@ class H2WP_GitHub_API {
 	 *   plugins: array of { slug, subdirectory, main_file } (monorepo only)
 	 * }
 	 */
-	public function detect_repo_type( $owner, $repo, $branch = '' ) {
-		$cache_key = 'repo_type_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $branch );
+	public function detect_repo_type( $owner, $repo, $branch = '', $repo_type = 'plugin' ) {
+    $repo_type = in_array( $repo_type, array( 'plugin', 'theme' ), true ) ? $repo_type : 'plugin';
+    $cache_key = 'repo_type_' . $repo_type . '_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $branch );
 		$cached    = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
@@ -1338,18 +1349,29 @@ class H2WP_GitHub_API {
 			return $root_contents;
 		}
 
-		// Check repo root for a plugin header
-		foreach ( $root_contents as $item ) {
-			if ( 'file' !== $item['type'] || substr( $item['name'], -4 ) !== '.php' ) {
-				continue;
-			}
-			$content = $this->get_file_content( $owner, $repo, $item['path'], $branch );
-			if ( ! is_wp_error( $content ) && $this->has_plugin_header( $content ) ) {
-				$result = array( 'type' => 'single', 'plugins' => array() );
-				H2WP_Cache::set( $cache_key, $result );
-				return $result;
-			}
-		}
+		// Check repo root for a plugin/theme header
+        foreach ( $root_contents as $item ) {
+            if ( 'file' !== $item['type'] ) {
+                continue;
+            }
+            if ( 'theme' === $repo_type ) {
+                if ( strtolower( $item['name'] ) !== 'style.css' ) { continue; }
+                $content = $this->get_file_content( $owner, $repo, $item['path'], $branch );
+                if ( ! is_wp_error( $content ) && $this->has_theme_header( $content ) ) {
+                    $result = array( 'type' => 'single', 'plugins' => array() );
+                    H2WP_Cache::set( $cache_key, $result );
+                    return $result;
+                }
+            } else {
+                if ( substr( $item['name'], -4 ) !== '.php' ) { continue; }
+                $content = $this->get_file_content( $owner, $repo, $item['path'], $branch );
+                if ( ! is_wp_error( $content ) && $this->has_plugin_header( $content ) ) {
+                    $result = array( 'type' => 'single', 'plugins' => array() );
+                    H2WP_Cache::set( $cache_key, $result );
+                    return $result;
+                }
+            }
+        }
 
 		// Scan one level of subdirectories.
 		// If a subdirectory contains no PHP files but only more subdirectories,
@@ -1366,23 +1388,28 @@ class H2WP_GitHub_API {
 				continue;
 			}
 
-			// Check whether this subdir directly contains a plugin PHP file
-			$found_here = false;
-			foreach ( $subdir_contents as $file ) {
-				if ( 'file' !== $file['type'] || substr( $file['name'], -4 ) !== '.php' ) {
-					continue;
-				}
-				$content = $this->get_file_content( $owner, $repo, $file['path'], $branch );
-				if ( ! is_wp_error( $content ) && $this->has_plugin_header( $content ) ) {
-					$found_plugins[] = array(
-						'slug'         => $item['name'],
-						'subdirectory' => $item['path'],
-						'main_file'    => $file['path'],
-					);
-					$found_here = true;
-					break;
-				}
-			}
+			// Check whether this subdir directly contains a plugin/theme file
+            $found_here = false;
+            foreach ( $subdir_contents as $file ) {
+                if ( 'file' !== $file['type'] ) { continue; }
+                $is_match = ( 'theme' === $repo_type )
+                    ? strtolower( $file['name'] ) === 'style.css'
+                    : substr( $file['name'], -4 ) === '.php';
+                if ( ! $is_match ) { continue; }
+                $content = $this->get_file_content( $owner, $repo, $file['path'], $branch );
+                $has_header = ( 'theme' === $repo_type )
+                    ? $this->has_theme_header( $content )
+                    : $this->has_plugin_header( $content );
+                if ( ! is_wp_error( $content ) && $has_header ) {
+                    $found_plugins[] = array(
+                        'slug'         => $item['name'],
+                        'subdirectory' => $item['path'],
+                        'main_file'    => $file['path'],
+                    );
+                    $found_here = true;
+                    break;
+                }
+            }
 
 			if ( $found_here ) {
 				continue;
@@ -1401,19 +1428,24 @@ class H2WP_GitHub_API {
 				}
 
 				foreach ( $deep_contents as $file ) {
-					if ( 'file' !== $file['type'] || substr( $file['name'], -4 ) !== '.php' ) {
-						continue;
-					}
-					$content = $this->get_file_content( $owner, $repo, $file['path'], $branch );
-					if ( ! is_wp_error( $content ) && $this->has_plugin_header( $content ) ) {
-						$found_plugins[] = array(
-							'slug'         => $subitem['name'],
-							'subdirectory' => $subitem['path'],
-							'main_file'    => $file['path'],
-						);
-						break;
-					}
-				}
+                    if ( 'file' !== $file['type'] ) { continue; }
+                    $is_match = ( 'theme' === $repo_type )
+                        ? strtolower( $file['name'] ) === 'style.css'
+                        : substr( $file['name'], -4 ) === '.php';
+                    if ( ! $is_match ) { continue; }
+                    $content = $this->get_file_content( $owner, $repo, $file['path'], $branch );
+                    $has_header = ( 'theme' === $repo_type )
+                        ? $this->has_theme_header( $content )
+                        : $this->has_plugin_header( $content );
+                    if ( ! is_wp_error( $content ) && $has_header ) {
+                        $found_plugins[] = array(
+                            'slug'         => $subitem['name'],
+                            'subdirectory' => $subitem['path'],
+                            'main_file'    => $file['path'],
+                        );
+                        break;
+                    }
+                }
 			}
 		}
 
@@ -1485,6 +1517,16 @@ class H2WP_GitHub_API {
 	 */
 	public function has_plugin_header( $content ) {
 		return false !== strpos( $content, 'Plugin Name:' );
+	}
+
+	/**
+	 * Check whether CSS content contains a WordPress theme header.
+	 *
+	 * @param string $content File content.
+	 * @return bool
+	 */
+	public function has_theme_header( $content ) {
+		return false !== strpos( $content, 'Theme Name:' );
 	}
 
 	/**

--- a/includes/class-h2wp-github-api.php
+++ b/includes/class-h2wp-github-api.php
@@ -873,11 +873,12 @@ class H2WP_GitHub_API {
 	 * @param string $branch Optional branch name.
 	 * @return array Compatibility data (is_compatible, reason) or error.
 	 */
-	public function check_compatibility( $owner, $repo, $repo_type = 'plugin', $branch = '', $prioritize_releases = true, $source_context = null ) {
+	public function check_compatibility( $owner, $repo, $repo_type = 'plugin', $branch = '', $prioritize_releases = true, $source_context = null, $subdirectory = '' ) {
 		$repo_type = in_array( $repo_type, array( 'plugin', 'theme' ), true ) ? $repo_type : 'plugin';
 		$source_context = is_array( $source_context ) ? $source_context : $this->resolve_version_source( $owner, $repo, $branch, $prioritize_releases );
 		$ref            = isset( $source_context['ref'] ) ? (string) $source_context['ref'] : $branch;
-		$cache_key      = 'compatibility_' . $repo_type . '_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $ref ) . '_' . ( ! empty( $source_context['source'] ) ? $source_context['source'] : 'branch' );
+		$subdir_key     = ! empty( $subdirectory ) ? '_' . md5( $subdirectory ) : '';
+		$cache_key      = 'compatibility_' . $repo_type . '_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $ref ) . '_' . ( ! empty( $source_context['source'] ) ? $source_context['source'] : 'branch' ) . $subdir_key;
 		$cached = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
@@ -895,7 +896,7 @@ class H2WP_GitHub_API {
 			}
 			$headers = $this->extract_headers_from_style( $style_content );
 		} else {
-			$readme_content = $this->fetch_readme_content( $owner, $repo, $ref );
+			$readme_content = $this->fetch_readme_content( $owner, $repo, $ref, $subdirectory );
 			if ( is_wp_error( $readme_content ) ) {
 				$error_data = array(
 					'is_compatible' => false,
@@ -944,8 +945,17 @@ class H2WP_GitHub_API {
 	 * @param string $branch Optional branch name.
 	 * @return string|WP_Error Readme content or error.
 	 */
-	private function fetch_readme_content( $owner, $repo, $branch = '' ) {
+	private function fetch_readme_content( $owner, $repo, $branch = '', $path_prefix = '' ) {
 		$filenames = array( 'readme.txt', 'README.txt' );
+
+		if ( ! empty( $path_prefix ) ) {
+			$filenames = array_map(
+				function( $f ) use ( $path_prefix ) {
+					return trailingslashit( $path_prefix ) . $f;
+				},
+				$filenames
+			);
+		}
 
 		foreach ( $filenames as $filename ) {
 			$url = $this->base_url . "/repos/{$owner}/{$repo}/contents/{$filename}";
@@ -967,7 +977,10 @@ class H2WP_GitHub_API {
 			}
 		}
 
-		// Fall back to the readme endpoint which will find README.md/readme.md/README etc.
+		// Fall back to the readme endpoint - only for single-repo plugins which will find README.md/readme.md/README etc. (always fetches root).
+		if ( ! empty( $path_prefix ) ) {
+			return new WP_Error( 'h2wp_readme_not_found', __( 'No valid readme file found.', 'hub2wp' ) );
+		}
 		$url = $this->base_url . "/repos/{$owner}/{$repo}/readme";
 		if ( ! empty( $branch ) ) {
 			$url = add_query_arg( 'ref', $branch, $url );
@@ -1131,16 +1144,17 @@ class H2WP_GitHub_API {
 	 * @param string $branch Optional branch name.
 	 * @return array|WP_Error Parsed headers or error.
 	 */
-	public function get_readme_headers( $owner, $repo, $branch = '', $prioritize_releases = true, $source_context = null ) {
+	public function get_readme_headers( $owner, $repo, $branch = '', $prioritize_releases = true, $source_context = null, $subdirectory = '' ) {
 		$source_context = is_array( $source_context ) ? $source_context : $this->resolve_version_source( $owner, $repo, $branch, $prioritize_releases );
 		$ref            = isset( $source_context['ref'] ) ? (string) $source_context['ref'] : $branch;
-		$cache_key      = 'readme_headers_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $ref ) . '_' . ( ! empty( $source_context['source'] ) ? $source_context['source'] : 'branch' );
+		$subdir_key     = ! empty( $subdirectory ) ? '_' . md5( $subdirectory ) : '';
+		$cache_key      = 'readme_headers_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $ref ) . '_' . ( ! empty( $source_context['source'] ) ? $source_context['source'] : 'branch' ) . $subdir_key;
 		$cached = H2WP_Cache::get( $cache_key );
 		if ( false !== $cached ) {
 			return $cached;
 		}
 
-		$readme_content = $this->fetch_readme_content( $owner, $repo, $ref );
+		$readme_content = $this->fetch_readme_content( $owner, $repo, $ref, $subdirectory );
 		if ( is_wp_error( $readme_content ) ) {
 			return $readme_content;
 		}
@@ -1295,5 +1309,237 @@ class H2WP_GitHub_API {
 		H2WP_Cache::set( $cache_key, $changelog, HOUR_IN_SECONDS );
 
 		return $changelog;
+	}
+
+	/**
+	 * Detect whether a repository is a single plugin or a monorepo.
+	 *
+	 * Checks the repo root for a WordPress plugin header. If none is found,
+	 * scans one level of subdirectories. Returns 'single' or 'monorepo' with
+	 * a list of discovered plugins.
+	 *
+	 * @param string $owner  Repository owner.
+	 * @param string $repo   Repository name.
+	 * @param string $branch Optional branch.
+	 * @return array|WP_Error {
+	 *   type: 'single'|'monorepo',
+	 *   plugins: array of { slug, subdirectory, main_file } (monorepo only)
+	 * }
+	 */
+	public function detect_repo_type( $owner, $repo, $branch = '' ) {
+		$cache_key = 'repo_type_' . $owner . '_' . $repo . '_' . $this->get_branch_cache_key_segment( $branch );
+		$cached    = H2WP_Cache::get( $cache_key );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$root_contents = $this->get_directory_contents( $owner, $repo, '', $branch );
+		if ( is_wp_error( $root_contents ) ) {
+			return $root_contents;
+		}
+
+		// Check repo root for a plugin header
+		foreach ( $root_contents as $item ) {
+			if ( 'file' !== $item['type'] || substr( $item['name'], -4 ) !== '.php' ) {
+				continue;
+			}
+			$content = $this->get_file_content( $owner, $repo, $item['path'], $branch );
+			if ( ! is_wp_error( $content ) && $this->has_plugin_header( $content ) ) {
+				$result = array( 'type' => 'single', 'plugins' => array() );
+				H2WP_Cache::set( $cache_key, $result );
+				return $result;
+			}
+		}
+
+		// Scan one level of subdirectories.
+		// If a subdirectory contains no PHP files but only more subdirectories,
+		// treat it as a container folder (e.g. /plugins/) and scan one level deeper.
+		$found_plugins = array();
+
+		foreach ( $root_contents as $item ) {
+			if ( 'dir' !== $item['type'] ) {
+				continue;
+			}
+
+			$subdir_contents = $this->get_directory_contents( $owner, $repo, $item['path'], $branch );
+			if ( is_wp_error( $subdir_contents ) ) {
+				continue;
+			}
+
+			// Check whether this subdir directly contains a plugin PHP file
+			$found_here = false;
+			foreach ( $subdir_contents as $file ) {
+				if ( 'file' !== $file['type'] || substr( $file['name'], -4 ) !== '.php' ) {
+					continue;
+				}
+				$content = $this->get_file_content( $owner, $repo, $file['path'], $branch );
+				if ( ! is_wp_error( $content ) && $this->has_plugin_header( $content ) ) {
+					$found_plugins[] = array(
+						'slug'         => $item['name'],
+						'subdirectory' => $item['path'],
+						'main_file'    => $file['path'],
+					);
+					$found_here = true;
+					break;
+				}
+			}
+
+			if ( $found_here ) {
+				continue;
+			}
+
+			// No plugin PHP file found directly — check if this is a container
+			// folder (like /plugins/) by scanning its subdirectories one level deeper
+			foreach ( $subdir_contents as $subitem ) {
+				if ( 'dir' !== $subitem['type'] ) {
+					continue;
+				}
+
+				$deep_contents = $this->get_directory_contents( $owner, $repo, $subitem['path'], $branch );
+				if ( is_wp_error( $deep_contents ) ) {
+					continue;
+				}
+
+				foreach ( $deep_contents as $file ) {
+					if ( 'file' !== $file['type'] || substr( $file['name'], -4 ) !== '.php' ) {
+						continue;
+					}
+					$content = $this->get_file_content( $owner, $repo, $file['path'], $branch );
+					if ( ! is_wp_error( $content ) && $this->has_plugin_header( $content ) ) {
+						$found_plugins[] = array(
+							'slug'         => $subitem['name'],
+							'subdirectory' => $subitem['path'],
+							'main_file'    => $file['path'],
+						);
+						break;
+					}
+				}
+			}
+		}
+
+		if ( ! empty( $found_plugins ) ) {
+			$result = array( 'type' => 'monorepo', 'plugins' => $found_plugins );
+			H2WP_Cache::set( $cache_key, $result );
+			return $result;
+		}
+
+		return new WP_Error( 'h2wp_no_plugin_found', __( 'No WordPress plugins found in this repository.', 'hub2wp' ) );
+	}
+
+	/**
+	 * Get the contents listing of a directory in a repository.
+	 *
+	 * @param string $owner  Repository owner.
+	 * @param string $repo   Repository name.
+	 * @param string $path   Directory path (empty string for root).
+	 * @param string $branch Optional branch/ref.
+	 * @return array|WP_Error
+	 */
+	public function get_directory_contents( $owner, $repo, $path = '', $branch = '' ) {
+		$url = $this->base_url . '/repos/' . $owner . '/' . $repo . '/contents/' . ltrim( $path, '/' );
+		if ( ! empty( $branch ) ) {
+			$url = add_query_arg( 'ref', $branch, $url );
+		}
+		$response = $this->request( $url );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$contents = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $contents ) ) {
+			return new WP_Error( 'h2wp_api_error', __( 'Invalid directory contents from GitHub API.', 'hub2wp' ) );
+		}
+		return $contents;
+	}
+
+	/**
+	 * Get the decoded text content of a file from a repository.
+	 *
+	 * @param string $owner  Repository owner.
+	 * @param string $repo   Repository name.
+	 * @param string $path   File path within the repo.
+	 * @param string $branch Optional branch/ref.
+	 * @return string|WP_Error
+	 */
+	public function get_file_content( $owner, $repo, $path, $branch = '' ) {
+		$url = $this->base_url . '/repos/' . $owner . '/' . $repo . '/contents/' . ltrim( $path, '/' );
+		if ( ! empty( $branch ) ) {
+			$url = add_query_arg( 'ref', $branch, $url );
+		}
+		$response = $this->request( $url );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $data ) || ! isset( $data['content'] ) ) {
+			return new WP_Error( 'h2wp_api_error', __( 'Invalid file data from GitHub API.', 'hub2wp' ) );
+		}
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		return base64_decode( $data['content'] );
+	}
+
+	/**
+	 * Check whether PHP file content contains a WordPress plugin header.
+	 *
+	 * @param string $content File content.
+	 * @return bool
+	 */
+	public function has_plugin_header( $content ) {
+		return false !== strpos( $content, 'Plugin Name:' );
+	}
+
+	/**
+	 * Get the download URL for a specific plugin's release asset from a monorepo.
+	 *
+	 * Finds the latest GitHub release tagged "{plugin_slug}/v*" and returns
+	 * the URL of its first zip asset, or the release zipball as a fallback.
+	 *
+	 * @param string $owner       Repository owner.
+	 * @param string $repo        Repository name.
+	 * @param string $plugin_slug Plugin folder name (e.g. "custom-plugin-one").
+	 * @return string|WP_Error Asset download URL or error.
+	 */
+	public function get_monorepo_release_asset_url( $owner, $repo, $plugin_slug ) {
+		$cache_key = 'monorepo_asset_' . $owner . '_' . $repo . '_' . sanitize_key( $plugin_slug );
+		$cached    = H2WP_Cache::get( $cache_key );
+		if ( false !== $cached ) {
+			return $cached;
+		}
+
+		$url      = $this->base_url . '/repos/' . $owner . '/' . $repo . '/releases';
+		$response = $this->request( $url );
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$releases = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $releases ) ) {
+			return new WP_Error( 'h2wp_api_error', __( 'Invalid releases data from GitHub API.', 'hub2wp' ) );
+		}
+
+		$tag_prefix = $plugin_slug . '/v';
+		foreach ( $releases as $release ) {
+			if ( empty( $release['tag_name'] ) ) {
+				continue;
+			}
+			if ( 0 !== strpos( $release['tag_name'], $tag_prefix ) ) {
+				continue;
+			}
+			// Prefer an explicit zip asset attached to the release
+			if ( ! empty( $release['assets'] ) ) {
+				foreach ( $release['assets'] as $asset ) {
+					if ( isset( $asset['content_type'] ) && 'application/zip' === $asset['content_type'] ) {
+						$result = esc_url_raw( $asset['url'] );
+						H2WP_Cache::set( $cache_key, $result );
+						return $result;
+					}
+				}
+			}
+			// Fallback: the release's auto-generated full-repo zipball
+			$result = esc_url_raw( $release['zipball_url'] );
+			H2WP_Cache::set( $cache_key, $result );
+			return $result;
+		}
+
+		return new WP_Error( 'h2wp_no_release', __( 'No matching release found for this plugin.', 'hub2wp' ) );
 	}
 }

--- a/includes/class-h2wp-plugin-installer.php
+++ b/includes/class-h2wp-plugin-installer.php
@@ -239,6 +239,19 @@ class H2WP_Plugin_Installer {
 
         $final_dest = trailingslashit( $remote_source ) . $this->install_target_folder;
 
+        // Clean up any partial/leftover installation in the actual destination directories.
+        // WordPress won't overwrite an existing folder, causing "Failed to install" on retry.
+        $possible_final_dirs = array(
+            WP_PLUGIN_DIR . '/' . $this->install_target_folder,
+            get_theme_root() . '/' . $this->install_target_folder,
+        );
+        foreach ( $possible_final_dirs as $possible_dir ) {
+            if ( $wp_filesystem->is_dir( $possible_dir ) ) {
+                $wp_filesystem->delete( $possible_dir, true );
+                break;
+            }
+        }
+
         // Monorepo: the zip contains the full repo; navigate into the plugin subdirectory
         if ( ! empty( $this->install_subdirectory ) ) {
             $plugin_source = trailingslashit( $source ) . $this->install_subdirectory;

--- a/includes/class-h2wp-plugin-installer.php
+++ b/includes/class-h2wp-plugin-installer.php
@@ -89,7 +89,7 @@ class H2WP_Plugin_Installer {
 	 * @param string $access_token Optional GitHub access token for private repos.
 	 * @return bool|WP_Error True on success, WP_Error on failure.
 	 */
-	public function install_theme( $download_url, $access_token = '' ) {
+	public function install_theme( $download_url, $access_token = '', $subdirectory = '' ) {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 		$upgrader = new Theme_Upgrader( new H2WP_Silent_Installer_Skin() );
@@ -105,17 +105,21 @@ class H2WP_Plugin_Installer {
 			$package = $download_url;
 		}
 
-		$this->install_target_folder = $this->get_repo_slug_from_download_url( $download_url );
-		add_filter( 'upgrader_source_selection', array( $this, 'normalize_install_source_folder' ), 10, 4 );
+		$this->install_subdirectory  = trim( (string) $subdirectory, '/' );
+        $this->install_target_folder = ! empty( $subdirectory )
+            ? basename( $subdirectory )
+            : $this->get_repo_slug_from_download_url( $download_url );
+        add_filter( 'upgrader_source_selection', array( $this, 'normalize_install_source_folder' ), 10, 4 );
 
 		ob_start();
 		$result = $upgrader->install( $package );
 		ob_end_clean();
 		remove_filter( 'upgrader_source_selection', array( $this, 'normalize_install_source_folder' ), 10 );
-		$this->install_target_folder = '';
+        $this->install_target_folder = '';
+        $this->install_subdirectory  = '';
 
-		// Always clean up the temp file.
-		if ( null !== $local_file && file_exists( $local_file ) ) {
+        // Always clean up the temp file.
+        if ( null !== $local_file && file_exists( $local_file ) ) {
 			// phpcs:ignore -- WordPress.PHP.NoSilencedErrors.Discouraged & WordPress.WP.AlternativeFunctions.file_system_read_file -- We want to suppress errors here since the file might not exist or be deletable, and there's no real alternative function for this.
 			@unlink( $local_file );
 		}

--- a/includes/class-h2wp-plugin-installer.php
+++ b/includes/class-h2wp-plugin-installer.php
@@ -15,8 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 class H2WP_Plugin_Installer {
 
 	public $plugin_data = array();
-	public $theme_data  = array();
-	private $install_target_folder = '';
+    public $theme_data  = array();
+    private $install_target_folder = '';
+    private $install_subdirectory  = ''; // subdirectory within the zip for monorepo plugins
 
 	/**
 	 * Install a plugin from a GitHub ZIP URL.
@@ -25,7 +26,7 @@ class H2WP_Plugin_Installer {
 	 * @param string $access_token  Optional GitHub access token for private repos.
 	 * @return bool|WP_Error True on success, WP_Error on failure.
 	 */
-	public function install_plugin( $download_url, $access_token = '' ) {
+	public function install_plugin( $download_url, $access_token = '', $subdirectory = '' ) {
 		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 		$upgrader = new Plugin_Upgrader( new H2WP_Silent_Installer_Skin() );
@@ -43,17 +44,22 @@ class H2WP_Plugin_Installer {
 			$package = $download_url;
 		}
 
-		$this->install_target_folder = $this->get_repo_slug_from_download_url( $download_url );
-		add_filter( 'upgrader_source_selection', array( $this, 'normalize_install_source_folder' ), 10, 4 );
+		// For monorepo plugins, target the plugin slug; for single repos, use the repo slug
+        $this->install_subdirectory  = trim( (string) $subdirectory, '/' );
+        $this->install_target_folder = ! empty( $subdirectory )
+            ? basename( $subdirectory )
+            : $this->get_repo_slug_from_download_url( $download_url );
+        add_filter( 'upgrader_source_selection', array( $this, 'normalize_install_source_folder' ), 10, 4 );
 
 		ob_start();
 		$result = $upgrader->install( $package );
 		ob_end_clean();
 		remove_filter( 'upgrader_source_selection', array( $this, 'normalize_install_source_folder' ), 10 );
-		$this->install_target_folder = '';
+        $this->install_target_folder = '';
+        $this->install_subdirectory  = '';
 
-		// Always clean up the temp file.
-		if ( null !== $local_file && file_exists( $local_file ) ) {
+        // Always clean up the temp file.
+        if ( null !== $local_file && file_exists( $local_file ) ) {
 			// phpcs:ignore -- WordPress.PHP.NoSilencedErrors.Discouraged & WordPress.WP.AlternativeFunctions.file_system_read_file -- We want to suppress errors here since the file might not exist or be deletable, and there's no real alternative function for this.
 			@unlink( $local_file );
 		}
@@ -217,33 +223,64 @@ class H2WP_Plugin_Installer {
 	 * @return string|WP_Error
 	 */
 	public function normalize_install_source_folder( $source, $remote_source, $upgrader, $hook_extra = array() ) {
-		global $wp_filesystem;
+        global $wp_filesystem;
 
-		if ( empty( $this->install_target_folder ) ) {
-			return $source;
-		}
+        if ( empty( $this->install_target_folder ) ) {
+            return $source;
+        }
 
-		$new_source = trailingslashit( $remote_source ) . $this->install_target_folder;
-		if ( trailingslashit( $new_source ) === trailingslashit( $source ) ) {
-			return $source;
-		}
+        if ( ! $wp_filesystem || ! method_exists( $wp_filesystem, 'move' ) ) {
+            return $source;
+        }
 
-		if ( ! $wp_filesystem || ! method_exists( $wp_filesystem, 'move' ) ) {
-			return $source;
-		}
+        $final_dest = trailingslashit( $remote_source ) . $this->install_target_folder;
 
-		if ( ! $wp_filesystem->move( untrailingslashit( $source ), $new_source ) ) {
-			return new WP_Error(
-				'h2wp_rename_error',
-				sprintf(
-					/* translators: 1: extracted folder, 2: expected folder */
-					__( 'Could not rename extracted folder from "%1$s" to "%2$s".', 'hub2wp' ),
-					basename( $source ),
-					$this->install_target_folder
-				)
-			);
-		}
+        // Monorepo: the zip contains the full repo; navigate into the plugin subdirectory
+        if ( ! empty( $this->install_subdirectory ) ) {
+            $plugin_source = trailingslashit( $source ) . $this->install_subdirectory;
 
-		return trailingslashit( $new_source );
-	}
+            if ( ! $wp_filesystem->is_dir( $plugin_source ) ) {
+                return new WP_Error(
+                    'h2wp_subdir_not_found',
+                    sprintf(
+                        /* translators: %s: subdirectory path */
+                        __( 'Plugin subdirectory "%s" not found in the downloaded zip.', 'hub2wp' ),
+                        $this->install_subdirectory
+                    )
+                );
+            }
+
+            // Move just the plugin folder out of the repo zip
+            if ( ! $wp_filesystem->move( untrailingslashit( $plugin_source ), $final_dest ) ) {
+                return new WP_Error(
+                    'h2wp_rename_error',
+                    __( 'Could not extract plugin subdirectory from the repository zip.', 'hub2wp' )
+                );
+            }
+
+            // Clean up the rest of the extracted repo
+            $wp_filesystem->delete( untrailingslashit( $source ), true );
+
+            return trailingslashit( $final_dest );
+        }
+
+        // Single repo: just rename the GitHub hash folder to the repo slug
+        if ( trailingslashit( $final_dest ) === trailingslashit( $source ) ) {
+            return $source;
+        }
+
+        if ( ! $wp_filesystem->move( untrailingslashit( $source ), $final_dest ) ) {
+            return new WP_Error(
+                'h2wp_rename_error',
+                sprintf(
+                    /* translators: 1: extracted folder, 2: expected folder */
+                    __( 'Could not rename extracted folder from "%1$s" to "%2$s".', 'hub2wp' ),
+                    basename( $source ),
+                    $this->install_target_folder
+                )
+            );
+        }
+
+        return trailingslashit( $final_dest );
+    }
 }

--- a/includes/class-h2wp-plugin-updater.php
+++ b/includes/class-h2wp-plugin-updater.php
@@ -66,14 +66,18 @@ class H2WP_Plugin_Updater {
 		$now             = time();
 
 		foreach ( $h2wp_plugins as $plugin_id => &$plugin ) {
-			list( $owner, $repo ) = explode( '/', $plugin_id );
+			$parts        = explode( '/', $plugin_id );
+			$owner        = $parts[0];
+			$repo         = $parts[1];
+			$subdirectory = isset( $plugin['subdirectory'] ) ? $plugin['subdirectory'] : '';
+
 			$tracking_preferences = H2WP_Settings::get_repo_tracking_preferences( $owner, $repo, 'plugin' );
 			$branch               = $tracking_preferences['branch'];
 			$prioritize_releases  = $tracking_preferences['prioritize_releases'];
-			$source_context      = $api->resolve_version_source( $owner, $repo, $branch, $prioritize_releases );
+			$source_context       = $api->resolve_version_source( $owner, $repo, $branch, $prioritize_releases );
 
-			// Get readme headers
-			$headers = $api->get_readme_headers( $owner, $repo, $branch, $prioritize_releases, $source_context );
+			// Get readme headers, passing subdirectory for monorepo plugins
+			$headers = $api->get_readme_headers( $owner, $repo, $branch, $prioritize_releases, $source_context, $subdirectory );
 			if ( is_wp_error( $headers ) || empty( $headers['stable tag'] ) ) {
 				if ( is_wp_error( $headers ) ) {
 					self::log_debug( sprintf( 'Plugin update check failed for %s: %s', $plugin_id, $headers->get_error_message() ) );
@@ -82,15 +86,23 @@ class H2WP_Plugin_Updater {
 			}
 
 			// Update plugin data
-			$plugin['version']      = $headers['stable tag'];
-			$plugin['requires']     = isset( $headers['requires at least'] ) ? $headers['requires at least'] : '';
-			$plugin['tested']       = isset( $headers['tested up to'] ) ? $headers['tested up to'] : '';
-			$plugin['requires_php'] = isset( $headers['requires php'] ) ? $headers['requires php'] : '';
-			$plugin['last_checked'] = $now;
-			$plugin['download_url'] = $source_context['download_url'];
-			$plugin['uses_releases'] = ! empty( $source_context['uses_releases'] );
-			$plugin['version_source'] = isset( $source_context['source'] ) ? $source_context['source'] : 'branch';
+			$plugin['version']             = $headers['stable tag'];
+			$plugin['requires']            = isset( $headers['requires at least'] ) ? $headers['requires at least'] : '';
+			$plugin['tested']              = isset( $headers['tested up to'] ) ? $headers['tested up to'] : '';
+			$plugin['requires_php']        = isset( $headers['requires php'] ) ? $headers['requires php'] : '';
+			$plugin['last_checked']        = $now;
+			$plugin['uses_releases']       = ! empty( $source_context['uses_releases'] );
+			$plugin['version_source']      = isset( $source_context['source'] ) ? $source_context['source'] : 'branch';
 			$plugin['prioritize_releases'] = $prioritize_releases;
+
+			// For monorepo plugins use the per-plugin release asset; fall back to full repo zip
+			if ( ! empty( $subdirectory ) ) {
+				$plugin_slug              = basename( $subdirectory );
+				$asset_url                = $api->get_monorepo_release_asset_url( $owner, $repo, $plugin_slug );
+				$plugin['download_url']   = is_wp_error( $asset_url ) ? $source_context['download_url'] : $asset_url;
+			} else {
+				$plugin['download_url'] = $source_context['download_url'];
+			}
 
 			$plugins_updated = true;
 		}
@@ -699,9 +711,13 @@ class H2WP_Plugin_Updater {
 				'filename'    => $tmpfname,
 				'redirection' => 5,
 				'headers'     => array(
-					'Authorization' => 'token ' . $access_token,
-					'Accept'        => 'application/vnd.github+json',
-				),
+                    'Authorization' => 'token ' . $access_token,
+                    // Release asset URLs need octet-stream to receive the file itself.
+                    // Zipball URLs need the standard API accept header.
+                    'Accept'        => ( false !== strpos( $package, '/releases/assets/' ) )
+                        ? 'application/octet-stream'
+                        : 'application/vnd.github+json',
+                ),
 			)
 		);
 
@@ -790,17 +806,23 @@ class H2WP_Plugin_Updater {
 	 * @return string
 	 */
 	private static function get_repo_key_from_package_url( $package ) {
-		$path = wp_parse_url( $package, PHP_URL_PATH );
-		if ( empty( $path ) ) {
-			return '';
-		}
+        $path = wp_parse_url( $package, PHP_URL_PATH );
+        if ( empty( $path ) ) {
+            return '';
+        }
 
-		if ( preg_match( '#/repos/([^/]+)/([^/]+)/zipball(?:/.*)?$#', $path, $matches ) ) {
-			return strtolower( $matches[1] . '/' . $matches[2] );
-		}
+        // Standard zipball: /repos/{owner}/{repo}/zipball/...
+        if ( preg_match( '#/repos/([^/]+)/([^/]+)/zipball(?:/.*)?$#', $path, $matches ) ) {
+            return strtolower( $matches[1] . '/' . $matches[2] );
+        }
 
-		return '';
-	}
+        // Release asset: /repos/{owner}/{repo}/releases/assets/{id}
+        if ( preg_match( '#/repos/([^/]+)/([^/]+)/releases/assets/#', $path, $matches ) ) {
+            return strtolower( $matches[1] . '/' . $matches[2] );
+        }
+
+        return '';
+    }
 
 	/**
 	 * Clean up scheduled events on plugin deactivation.

--- a/includes/class-h2wp-repo-manager.php
+++ b/includes/class-h2wp-repo-manager.php
@@ -70,7 +70,7 @@ class H2WP_Repo_Manager {
 
         $installer = new H2WP_Plugin_Installer();
         $result    = ( 'theme' === $repo_type )
-            ? $installer->install_theme( $download_url, $token )
+            ? $installer->install_theme( $download_url, $token, $subdirectory )
             : $installer->install_plugin( $download_url, $token, $subdirectory );
 
 		if ( is_wp_error( $result ) ) {

--- a/includes/class-h2wp-repo-manager.php
+++ b/includes/class-h2wp-repo-manager.php
@@ -103,30 +103,29 @@ class H2WP_Repo_Manager {
 			return new WP_Error( 'h2wp_plugin_file_not_found', __( 'The plugin was installed, but hub2wp could not determine its main plugin file for update tracking.', 'hub2wp' ) );
 		}
 
-		$headers      = isset( $compatibility['headers'] ) && is_array( $compatibility['headers'] ) ? $compatibility['headers'] : array();
-        $option_name  = 'h2wp_plugins';
-        $subdirectory = isset( $args['subdirectory'] ) ? trim( (string) $args['subdirectory'], '/' ) : '';
-        // Monorepo plugins use owner/repo/plugin-slug as key to avoid collisions
-        $repo_key     = ! empty( $subdirectory )
-            ? $owner . '/' . $repo . '/' . basename( $subdirectory )
-            : $owner . '/' . $repo;
-        $tracked_repos = get_option( $option_name, array() );
-		$existing     = isset( $tracked_repos[ $repo_key ] ) && is_array( $tracked_repos[ $repo_key ] ) ? $tracked_repos[ $repo_key ] : array();
-		$now          = time();
+		$headers       = isset( $compatibility['headers'] ) && is_array( $compatibility['headers'] ) ? $compatibility['headers'] : array();
+		$option_name   = 'h2wp_plugins';
+		$subdirectory  = isset( $args['subdirectory'] ) ? trim( (string) $args['subdirectory'], '/' ) : '';
+		$repo_key      = ! empty( $subdirectory )
+			? $owner . '/' . $repo . '/' . basename( $subdirectory )
+			: $owner . '/' . $repo;
+		$tracked_repos = get_option( $option_name, array() );
+		$existing      = isset( $tracked_repos[ $repo_key ] ) && is_array( $tracked_repos[ $repo_key ] ) ? $tracked_repos[ $repo_key ] : array();
+		$now           = time();
 
 		$tracked_repos[ $repo_key ] = self::build_tracked_repo_data(
 			array_merge(
 				$existing,
 				$plugin_data,
 				array(
-                    'owner'       => $owner,
-                    'repo'        => $repo,
-                    'repo_type'   => 'plugin',
-                    'plugin_file' => $plugin_file,
-                    'subdirectory'=> $subdirectory,
-					'version'     => isset( $headers['version'] ) ? $headers['version'] : ( isset( $plugin_data['version'] ) ? $plugin_data['version'] : '' ),
-					'requires'    => isset( $headers['requires at least'] ) ? $headers['requires at least'] : '',
-					'tested'      => isset( $headers['tested up to'] ) ? $headers['tested up to'] : '',
+					'owner'        => $owner,
+					'repo'         => $repo,
+					'repo_type'    => 'plugin',
+					'plugin_file'  => $plugin_file,
+					'subdirectory' => $subdirectory,
+					'version'      => isset( $headers['version'] ) ? $headers['version'] : ( isset( $plugin_data['version'] ) ? $plugin_data['version'] : '' ),
+					'requires'     => isset( $headers['requires at least'] ) ? $headers['requires at least'] : '',
+					'tested'       => isset( $headers['tested up to'] ) ? $headers['tested up to'] : '',
 					'requires_php' => isset( $headers['requires php'] ) ? $headers['requires php'] : '',
 				)
 			),
@@ -159,26 +158,39 @@ class H2WP_Repo_Manager {
 			return new WP_Error( 'h2wp_theme_stylesheet_not_found', __( 'The theme was installed, but hub2wp could not determine its stylesheet for update tracking.', 'hub2wp' ) );
 		}
 
-		$headers      = isset( $compatibility['headers'] ) && is_array( $compatibility['headers'] ) ? $compatibility['headers'] : array();
-		$option_name  = 'h2wp_themes';
-		$repo_key     = $owner . '/' . $repo;
+		$headers       = isset( $compatibility['headers'] ) && is_array( $compatibility['headers'] ) ? $compatibility['headers'] : array();
+		$option_name   = 'h2wp_themes';
+		$subdirectory  = isset( $args['subdirectory'] ) ? trim( (string) $args['subdirectory'], '/' ) : '';
+		$repo_key      = ! empty( $subdirectory )
+			? $owner . '/' . $repo . '/' . basename( $subdirectory )
+			: $owner . '/' . $repo;
 		$tracked_repos = get_option( $option_name, array() );
-		$existing     = isset( $tracked_repos[ $repo_key ] ) && is_array( $tracked_repos[ $repo_key ] ) ? $tracked_repos[ $repo_key ] : array();
-		$now          = time();
+
+		// Remove any legacy 2-part key entry to prevent duplicates after monorepo install
+		if ( ! empty( $subdirectory ) ) {
+			$legacy_key = $owner . '/' . $repo;
+			if ( isset( $tracked_repos[ $legacy_key ] ) && empty( $tracked_repos[ $legacy_key ]['subdirectory'] ) ) {
+				unset( $tracked_repos[ $legacy_key ] );
+			}
+		}
+
+		$existing = isset( $tracked_repos[ $repo_key ] ) && is_array( $tracked_repos[ $repo_key ] ) ? $tracked_repos[ $repo_key ] : array();
+		$now      = time();
 
 		$tracked_repos[ $repo_key ] = self::build_tracked_repo_data(
 			array_merge(
 				$existing,
 				$theme_data,
 				array(
-					'owner'       => $owner,
-					'repo'        => $repo,
-					'repo_type'   => 'theme',
-					'stylesheet'  => $stylesheet,
-					'template'    => ! empty( $theme_data['template'] ) ? $theme_data['template'] : $stylesheet,
-					'version'     => isset( $headers['version'] ) ? $headers['version'] : ( isset( $theme_data['version'] ) ? $theme_data['version'] : '' ),
-					'requires'    => isset( $headers['requires at least'] ) ? $headers['requires at least'] : '',
-					'tested'      => isset( $headers['tested up to'] ) ? $headers['tested up to'] : '',
+					'owner'        => $owner,
+					'repo'         => $repo,
+					'repo_type'    => 'theme',
+					'stylesheet'   => $stylesheet,
+					'template'     => ! empty( $theme_data['template'] ) ? $theme_data['template'] : $stylesheet,
+					'subdirectory' => $subdirectory,
+					'version'      => isset( $headers['version'] ) ? $headers['version'] : ( isset( $theme_data['version'] ) ? $theme_data['version'] : '' ),
+					'requires'     => isset( $headers['requires at least'] ) ? $headers['requires at least'] : '',
+					'tested'       => isset( $headers['tested up to'] ) ? $headers['tested up to'] : '',
 					'requires_php' => isset( $headers['requires php'] ) ? $headers['requires php'] : '',
 				)
 			),

--- a/includes/class-h2wp-repo-manager.php
+++ b/includes/class-h2wp-repo-manager.php
@@ -19,15 +19,16 @@ class H2WP_Repo_Manager {
 	 */
 	public static function install_repository( $owner, $repo, $args = array() ) {
 		$args = wp_parse_args(
-			$args,
-			array(
-				'repo_type'           => 'plugin',
-				'branch'              => '',
-				'prioritize_releases' => true,
-				'access_token'        => '',
-				'private'             => null,
-			)
-		);
+            $args,
+            array(
+                'repo_type'           => 'plugin',
+                'branch'              => '',
+                'prioritize_releases' => true,
+                'access_token'        => '',
+                'private'             => null,
+                'subdirectory'        => '', // path to plugin within a monorepo
+            )
+        );
 
 		list( $owner, $repo ) = self::normalize_repository_identifier( $owner, $repo );
 
@@ -45,21 +46,32 @@ class H2WP_Repo_Manager {
 
 		$api            = new H2WP_GitHub_API( $token );
 		$source_context = $api->resolve_version_source( $owner, $repo, $branch, ! empty( $args['prioritize_releases'] ) );
-		$compatibility  = $api->check_compatibility( $owner, $repo, $repo_type, $branch, ! empty( $args['prioritize_releases'] ), $source_context );
+		$subdirectory   = is_string( $args['subdirectory'] ) ? trim( $args['subdirectory'], '/' ) : '';
+        $compatibility  = $api->check_compatibility( $owner, $repo, $repo_type, $branch, ! empty( $args['prioritize_releases'] ), $source_context, $subdirectory );
 
-		if ( empty( $compatibility['is_compatible'] ) ) {
-			$message = ! empty( $compatibility['reason'] ) ? $compatibility['reason'] : __( 'The repository is not a compatible WordPress extension.', 'hub2wp' );
-			return new WP_Error( 'h2wp_incompatible_repository', $message );
-		}
+        if ( empty( $compatibility['is_compatible'] ) ) {
+            $message = ! empty( $compatibility['reason'] ) ? $compatibility['reason'] : __( 'The repository is not a compatible WordPress extension.', 'hub2wp' );
+            return new WP_Error( 'h2wp_incompatible_repository', $message );
+        }
 
-		if ( empty( $source_context['download_url'] ) ) {
-			return new WP_Error( 'h2wp_missing_download_url', __( 'Could not determine a download URL for this repository.', 'hub2wp' ) );
-		}
+        if ( empty( $source_context['download_url'] ) ) {
+            return new WP_Error( 'h2wp_missing_download_url', __( 'Could not determine a download URL for this repository.', 'hub2wp' ) );
+        }
 
-		$installer = new H2WP_Plugin_Installer();
-		$result    = ( 'theme' === $repo_type )
-			? $installer->install_theme( $source_context['download_url'], $token )
-			: $installer->install_plugin( $source_context['download_url'], $token );
+        // For monorepo plugins, use the per-plugin release asset if available
+        $download_url = $source_context['download_url'];
+        if ( ! empty( $subdirectory ) && 'plugin' === $repo_type ) {
+            $plugin_slug = basename( $subdirectory );
+            $asset_url   = $api->get_monorepo_release_asset_url( $owner, $repo, $plugin_slug );
+            if ( ! is_wp_error( $asset_url ) ) {
+                $download_url = $asset_url;
+            }
+        }
+
+        $installer = new H2WP_Plugin_Installer();
+        $result    = ( 'theme' === $repo_type )
+            ? $installer->install_theme( $download_url, $token )
+            : $installer->install_plugin( $download_url, $token, $subdirectory );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
@@ -92,9 +104,13 @@ class H2WP_Repo_Manager {
 		}
 
 		$headers      = isset( $compatibility['headers'] ) && is_array( $compatibility['headers'] ) ? $compatibility['headers'] : array();
-		$option_name  = 'h2wp_plugins';
-		$repo_key     = $owner . '/' . $repo;
-		$tracked_repos = get_option( $option_name, array() );
+        $option_name  = 'h2wp_plugins';
+        $subdirectory = isset( $args['subdirectory'] ) ? trim( (string) $args['subdirectory'], '/' ) : '';
+        // Monorepo plugins use owner/repo/plugin-slug as key to avoid collisions
+        $repo_key     = ! empty( $subdirectory )
+            ? $owner . '/' . $repo . '/' . basename( $subdirectory )
+            : $owner . '/' . $repo;
+        $tracked_repos = get_option( $option_name, array() );
 		$existing     = isset( $tracked_repos[ $repo_key ] ) && is_array( $tracked_repos[ $repo_key ] ) ? $tracked_repos[ $repo_key ] : array();
 		$now          = time();
 
@@ -103,10 +119,11 @@ class H2WP_Repo_Manager {
 				$existing,
 				$plugin_data,
 				array(
-					'owner'       => $owner,
-					'repo'        => $repo,
-					'repo_type'   => 'plugin',
-					'plugin_file' => $plugin_file,
+                    'owner'       => $owner,
+                    'repo'        => $repo,
+                    'repo_type'   => 'plugin',
+                    'plugin_file' => $plugin_file,
+                    'subdirectory'=> $subdirectory,
 					'version'     => isset( $headers['version'] ) ? $headers['version'] : ( isset( $plugin_data['version'] ) ? $plugin_data['version'] : '' ),
 					'requires'    => isset( $headers['requires at least'] ) ? $headers['requires at least'] : '',
 					'tested'      => isset( $headers['tested up to'] ) ? $headers['tested up to'] : '',

--- a/includes/class-h2wp-settings.php
+++ b/includes/class-h2wp-settings.php
@@ -230,20 +230,44 @@ class H2WP_Settings {
 			</form>
 
 			<?php if ( ! empty( $monitored_plugins ) ) : ?>
-				<h3><?php esc_html_e( 'Monitored Plugins', 'hub2wp' ); ?></h3>
-				<table class="wp-list-table widefat fixed striped">
-					<thead>
-						<tr>
-							<th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
-							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
-							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
-						</tr>
-					</thead>
-					<tbody>
-						<?php foreach ( $monitored_plugins as $repo_data ) : ?>
-							<?php $repo_key = isset( $repo_data['repo'] ) ? $repo_data['repo'] : ''; ?>
-							<tr>
-								<td>
+                <h3><?php esc_html_e( 'Monitored Plugins', 'hub2wp' ); ?></h3>
+                <form method="post" action="" id="h2wp-single-remove-form" style="display:none;">
+                    <?php wp_nonce_field( 'h2wp_remove_private_repo', 'h2wp_remove_repo_nonce' ); ?>
+                    <input type="hidden" name="h2wp_action" value="remove_private_repo" />
+                    <input type="hidden" name="h2wp_repo_key" id="h2wp-single-remove-key" value="" />
+                </form>
+                <form method="post" action="" id="h2wp-bulk-remove-form">
+                    <?php wp_nonce_field( 'h2wp_bulk_remove_repos', 'h2wp_bulk_remove_nonce' ); ?>
+                    <input type="hidden" name="h2wp_action" value="bulk_remove_repos" />
+                    <div class="tablenav top" style="margin-bottom:6px;">
+                        <div class="alignleft actions">
+                            <button type="submit" id="h2wp-bulk-remove-btn" class="button" disabled
+                                onclick="return confirm('<?php echo esc_js( __( 'Stop monitoring the selected repositories?', 'hub2wp' ) ); ?>');">
+                                <?php esc_html_e( 'Remove Selected', 'hub2wp' ); ?>
+                            </button>
+                        </div>
+                    </div>
+                <table class="wp-list-table widefat fixed striped">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="manage-column column-cb check-column" style="padding: 18px 3px 17px;">
+                                <input type="checkbox" id="h2wp-select-all-monitored" />
+                            </th>
+                            <th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
+                            <th style="width:80px;max-width:80px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
+                            <th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ( $monitored_plugins as $repo_data ) : ?>
+                            <?php $repo_key = isset( $repo_data['repo'] ) ? $repo_data['repo'] : ''; ?>
+                            <tr>
+                                <th scope="row" class="check-column">
+                                    <input type="checkbox" name="h2wp_repo_keys[]"
+                                        value="<?php echo esc_attr( $repo_key ); ?>"
+                                        class="h2wp-monitored-cb" />
+                                </th>
+                                <td>
 									<strong><?php echo esc_html( isset( $repo_data['name'] ) ? $repo_data['name'] : $repo_key ); ?></strong>
 									<br />
 									<small>
@@ -271,32 +295,30 @@ class H2WP_Settings {
 									?>
 								</td>
 								<td>
-									<form method="post" action="" style="display: inline;">
-										<?php wp_nonce_field( 'h2wp_remove_private_repo', 'h2wp_remove_repo_nonce' ); ?>
-										<input type="hidden" name="h2wp_action" value="remove_private_repo" />
-										<input type="hidden" name="h2wp_repo_key" value="<?php echo esc_attr( $repo_key ); ?>" />
-										<?php // Translators: %s is the repository name (owner/repo). ?>
-										<button type="submit" class="button button-small button-link-delete" onclick="return confirm('<?php echo esc_js( sprintf( __( 'Stop monitoring "%s"?', 'hub2wp' ), $repo_key ) ); ?>');">
-											<?php esc_html_e( 'Remove', 'hub2wp' ); ?>
-										</button>
-									</form>
-								</td>
+                                    <button type="button"
+                                        class="button button-small button-link-delete h2wp-single-remove-btn"
+                                        data-repo-key="<?php echo esc_attr( $repo_key ); ?>"
+                                        data-confirm="<?php echo esc_js( sprintf( __( 'Stop monitoring "%s"?', 'hub2wp' ), $repo_key ) ); ?>">
+                                        <?php esc_html_e( 'Remove', 'hub2wp' ); ?>
+                                    </button>
+                                </td>
 							</tr>
 						<?php endforeach; ?>
 					</tbody>
 				</table>
-				<p class="description">
-					<?php
-					echo wp_kses_post(
-						sprintf(
-							/* translators: %s: URL to the Private tab */
-							__( 'These repositories will be monitored for updates. Private repositories can be installed via the <a href="%s">Private tab</a> in Plugins > Add GitHub Plugin.', 'hub2wp' ),
-							esc_url( admin_url( 'plugins.php?page=h2wp-plugin-browser&tab=private' ) )
-						)
-					);
-					?>
-				</p>
-			<?php else : ?>
+				</form>
+                <p class="description">
+                    <?php
+                    echo wp_kses_post(
+                        sprintf(
+                            /* translators: %s: URL to the Private tab */
+                            __( 'These repositories will be monitored for updates. Private repositories can be installed via the <a href="%s">Private tab</a> in Plugins > Add GitHub Plugin.', 'hub2wp' ),
+                            esc_url( admin_url( 'plugins.php?page=h2wp-plugin-browser&tab=private' ) )
+                        )
+                    );
+                    ?>
+                </p>
+            <?php else : ?>
 				<p class="description">
 					<?php esc_html_e( 'No repositories added yet.', 'hub2wp' ); ?>
 				</p>
@@ -309,6 +331,43 @@ class H2WP_Settings {
 			var label   = document.getElementById( 'h2wp-toggle-monitored-label' );
 			var icon    = btn ? btn.querySelector( '.dashicons' ) : null;
 			if ( ! btn || ! content ) { return; }
+
+			// Bulk remove: select all / deselect all
+			var selectAll   = document.getElementById( 'h2wp-select-all-monitored' );
+			var bulkBtn     = document.getElementById( 'h2wp-bulk-remove-btn' );
+			var updateBulkBtn = function() {
+				var checked = document.querySelectorAll( '.h2wp-monitored-cb:checked' ).length;
+				if ( bulkBtn ) { bulkBtn.disabled = checked === 0; }
+			};
+			if ( selectAll ) {
+				selectAll.addEventListener( 'change', function() {
+					document.querySelectorAll( '.h2wp-monitored-cb' ).forEach( function( cb ) {
+						cb.checked = selectAll.checked;
+					} );
+					updateBulkBtn();
+				} );
+			}
+			// Individual remove buttons — use the shared hidden form to avoid nested forms
+			document.querySelectorAll( '.h2wp-single-remove-btn' ).forEach( function( btn ) {
+				btn.addEventListener( 'click', function() {
+					var repoKey    = this.getAttribute( 'data-repo-key' );
+					var confirmMsg = this.getAttribute( 'data-confirm' );
+					if ( ! confirm( confirmMsg ) ) { return; }
+					document.getElementById( 'h2wp-single-remove-key' ).value = repoKey;
+					document.getElementById( 'h2wp-single-remove-form' ).submit();
+				} );
+			} );
+			document.querySelectorAll( '.h2wp-monitored-cb' ).forEach( function( cb ) {
+				cb.addEventListener( 'change', function() {
+					var total   = document.querySelectorAll( '.h2wp-monitored-cb' ).length;
+					var checked = document.querySelectorAll( '.h2wp-monitored-cb:checked' ).length;
+					if ( selectAll ) {
+						selectAll.checked       = checked === total;
+						selectAll.indeterminate = checked > 0 && checked < total;
+					}
+					updateBulkBtn();
+				} );
+			} );
 			btn.addEventListener( 'click', function( e ) {
 				e.preventDefault();
 				var isExpanded = this.getAttribute( 'aria-expanded' ) === 'true';
@@ -575,17 +634,19 @@ class H2WP_Settings {
 	public static function handle_private_repo_actions() {
 		// Verify at least one of the expected nonces before reading any POST data.
 		$add_nonce_valid    = isset( $_POST['h2wp_private_repo_nonce'] )
-			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_private_repo_nonce'] ) ), 'h2wp_add_private_repo' );
-		$remove_nonce_valid = isset( $_POST['h2wp_remove_repo_nonce'] )
-			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_remove_repo_nonce'] ) ), 'h2wp_remove_private_repo' );
-		$add_theme_nonce_valid = isset( $_POST['h2wp_private_theme_repo_nonce'] )
-			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_private_theme_repo_nonce'] ) ), 'h2wp_add_private_theme_repo' );
-		$remove_theme_nonce_valid = isset( $_POST['h2wp_remove_theme_repo_nonce'] )
-			&& wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_remove_theme_repo_nonce'] ) ), 'h2wp_remove_private_theme_repo' );
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_private_repo_nonce'] ) ), 'h2wp_add_private_repo' );
+        $remove_nonce_valid = isset( $_POST['h2wp_remove_repo_nonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_remove_repo_nonce'] ) ), 'h2wp_remove_private_repo' );
+        $add_theme_nonce_valid = isset( $_POST['h2wp_private_theme_repo_nonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_private_theme_repo_nonce'] ) ), 'h2wp_add_private_theme_repo' );
+        $remove_theme_nonce_valid = isset( $_POST['h2wp_remove_theme_repo_nonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_remove_theme_repo_nonce'] ) ), 'h2wp_remove_private_theme_repo' );
+        $bulk_remove_nonce_valid = isset( $_POST['h2wp_bulk_remove_nonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_bulk_remove_nonce'] ) ), 'h2wp_bulk_remove_repos' );
 
-		if ( ! $add_nonce_valid && ! $remove_nonce_valid && ! $add_theme_nonce_valid && ! $remove_theme_nonce_valid ) {
-			return;
-		}
+        if ( ! $add_nonce_valid && ! $remove_nonce_valid && ! $add_theme_nonce_valid && ! $remove_theme_nonce_valid && ! $bulk_remove_nonce_valid ) {
+            return;
+        }
 
 		if ( ! isset( $_POST['h2wp_action'] ) ) {
 			return;
@@ -600,8 +661,10 @@ class H2WP_Settings {
 		} elseif ( 'add_private_theme_repo' === $action ) {
 			self::handle_add_private_theme_repo();
 		} elseif ( 'remove_private_theme_repo' === $action ) {
-			self::handle_remove_private_theme_repo();
-		}
+            self::handle_remove_private_theme_repo();
+        } elseif ( 'bulk_remove_repos' === $action ) {
+            self::handle_bulk_remove_repos();
+        }
 	}
 
 	/**
@@ -928,6 +991,50 @@ class H2WP_Settings {
 		}
 
 		add_settings_error( 'h2wp_theme_repos', 'h2wp_theme_repo_removed', sprintf( __( 'Theme repository "%s" has been removed.', 'hub2wp' ), $repo_key ), 'success' );
+	}
+
+	/**
+	 * Handle bulk removal of monitored plugin repositories.
+	 */
+	private static function handle_bulk_remove_repos() {
+		if ( ! isset( $_POST['h2wp_bulk_remove_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_bulk_remove_nonce'] ) ), 'h2wp_bulk_remove_repos' ) ) {
+			add_settings_error( 'h2wp_private_repos', 'h2wp_nonce_error', __( 'Security check failed. Please try again.', 'hub2wp' ), 'error' );
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			add_settings_error( 'h2wp_private_repos', 'h2wp_permission_error', __( 'You do not have permission to remove repositories.', 'hub2wp' ), 'error' );
+			return;
+		}
+
+		if ( empty( $_POST['h2wp_repo_keys'] ) || ! is_array( $_POST['h2wp_repo_keys'] ) ) {
+			add_settings_error( 'h2wp_private_repos', 'h2wp_no_selection', __( 'No repositories selected for removal.', 'hub2wp' ), 'warning' );
+			return;
+		}
+
+		$repo_keys         = array_map( 'sanitize_text_field', wp_unslash( $_POST['h2wp_repo_keys'] ) );
+		$monitored_plugins = get_option( 'h2wp_plugins', array() );
+		$removed           = 0;
+
+		foreach ( $repo_keys as $repo_key ) {
+			if ( isset( $monitored_plugins[ $repo_key ] ) ) {
+				unset( $monitored_plugins[ $repo_key ] );
+				$removed++;
+			}
+		}
+
+		update_option( 'h2wp_plugins', $monitored_plugins );
+
+		add_settings_error(
+			'h2wp_private_repos',
+			'h2wp_bulk_removed',
+			sprintf(
+				// Translators: %d is the number of repositories removed.
+				_n( '%d repository removed from monitoring.', '%d repositories removed from monitoring.', $removed, 'hub2wp' ),
+				$removed
+			),
+			'success'
+		);
 	}
 
 	/**

--- a/includes/class-h2wp-settings.php
+++ b/includes/class-h2wp-settings.php
@@ -464,61 +464,84 @@ class H2WP_Settings {
 			</form>
 
 			<?php if ( ! empty( $monitored_themes ) ) : ?>
-				<h3><?php esc_html_e( 'Monitored Themes', 'hub2wp' ); ?></h3>
-				<table class="wp-list-table widefat fixed striped">
-					<thead>
-						<tr>
-							<th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
-							<th style="width:100px;max-width:100px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
-							<th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
-						</tr>
-					</thead>
-					<tbody>
-						<?php foreach ( $monitored_themes as $repo_data ) : ?>
-							<?php $repo_key = isset( $repo_data['repo'] ) ? $repo_data['repo'] : ''; ?>
-							<tr>
-								<td>
-									<strong><?php echo esc_html( isset( $repo_data['name'] ) ? $repo_data['name'] : $repo_key ); ?></strong>
-									<br />
-									<small>
-										<a href="<?php echo esc_url( 'https://github.com/' . $repo_key ); ?>" target="_blank">
-											<?php echo esc_html( $repo_key ); ?>
-										</a><?php if ( ! empty( $repo_data['branch'] ) ) : ?> (<?php echo esc_html( $repo_data['branch'] ); ?>)<?php endif; ?>
-										<?php if ( array_key_exists( 'prioritize_releases', $repo_data ) && empty( $repo_data['prioritize_releases'] ) ) : ?>
-											&mdash; <?php esc_html_e( 'branch only', 'hub2wp' ); ?>
-										<?php endif; ?>
-										<?php if ( ! empty( $repo_data['stylesheet'] ) ) : ?>
-											&rarr; <code><?php echo esc_html( $repo_data['stylesheet'] ); ?></code>
-										<?php endif; ?>
-									</small>
-								</td>
-								<td>
-									<?php
-									if ( ! empty( $repo_data['installed'] ) ) {
-										esc_html_e( 'Installed', 'hub2wp' );
-									} else {
-										esc_html_e( 'Not Installed', 'hub2wp' );
-									}
-									if ( ! empty( $repo_data['private'] ) ) {
-										echo ' <span class="dashicons dashicons-lock" title="' . esc_attr__( 'Private Repository', 'hub2wp' ) . '"></span>';
-									}
-									?>
-								</td>
-								<td>
-									<form method="post" action="" style="display: inline;">
-										<?php wp_nonce_field( 'h2wp_remove_private_theme_repo', 'h2wp_remove_theme_repo_nonce' ); ?>
-										<input type="hidden" name="h2wp_action" value="remove_private_theme_repo" />
-										<input type="hidden" name="h2wp_repo_key" value="<?php echo esc_attr( $repo_key ); ?>" />
-										<button type="submit" class="button button-small button-link-delete" onclick="return confirm('<?php echo esc_js( sprintf( __( 'Stop monitoring "%s"?', 'hub2wp' ), $repo_key ) ); ?>');">
-											<?php esc_html_e( 'Remove', 'hub2wp' ); ?>
-										</button>
-									</form>
-								</td>
-							</tr>
-						<?php endforeach; ?>
-					</tbody>
-				</table>
-			<?php else : ?>
+                <h3><?php esc_html_e( 'Monitored Themes', 'hub2wp' ); ?></h3>
+                <form method="post" action="" id="h2wp-single-remove-theme-form" style="display:none;">
+                    <?php wp_nonce_field( 'h2wp_remove_private_theme_repo', 'h2wp_remove_theme_repo_nonce' ); ?>
+                    <input type="hidden" name="h2wp_action" value="remove_private_theme_repo" />
+                    <input type="hidden" name="h2wp_repo_key" id="h2wp-single-remove-theme-key" value="" />
+                </form>
+                <form method="post" action="" id="h2wp-bulk-remove-theme-form">
+                    <?php wp_nonce_field( 'h2wp_bulk_remove_theme_repos', 'h2wp_bulk_remove_theme_nonce' ); ?>
+                    <input type="hidden" name="h2wp_action" value="bulk_remove_theme_repos" />
+                    <div class="tablenav top" style="margin-bottom:6px;">
+                        <div class="alignleft actions">
+                            <button type="submit" id="h2wp-bulk-remove-theme-btn" class="button" disabled
+                                onclick="return confirm('<?php echo esc_js( __( 'Stop monitoring the selected theme repositories?', 'hub2wp' ) ); ?>');">
+                                <?php esc_html_e( 'Remove Selected', 'hub2wp' ); ?>
+                            </button>
+                        </div>
+                    </div>
+                    <table class="wp-list-table widefat fixed striped">
+                        <thead>
+                            <tr>
+                                <th scope="col" class="manage-column column-cb check-column" style="padding: 18px 3px 17px;">
+                                    <input type="checkbox" id="h2wp-select-all-monitored-themes" />
+                                </th>
+                                <th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
+                                <th style="width:100px;max-width:100px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
+                                <th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ( $monitored_themes as $repo_data ) : ?>
+                                <?php $repo_key = isset( $repo_data['repo'] ) ? $repo_data['repo'] : ''; ?>
+                                <tr>
+                                    <th scope="row" class="check-column">
+                                        <input type="checkbox" name="h2wp_repo_keys[]"
+                                            value="<?php echo esc_attr( $repo_key ); ?>"
+                                            class="h2wp-monitored-theme-cb" />
+                                    </th>
+                                    <td>
+                                        <strong><?php echo esc_html( isset( $repo_data['name'] ) ? $repo_data['name'] : $repo_key ); ?></strong>
+                                        <br />
+                                        <small>
+                                            <a href="<?php echo esc_url( 'https://github.com/' . $repo_key ); ?>" target="_blank">
+                                                <?php echo esc_html( $repo_key ); ?>
+                                            </a><?php if ( ! empty( $repo_data['branch'] ) ) : ?> (<?php echo esc_html( $repo_data['branch'] ); ?>)<?php endif; ?>
+                                            <?php if ( array_key_exists( 'prioritize_releases', $repo_data ) && empty( $repo_data['prioritize_releases'] ) ) : ?>
+                                                &mdash; <?php esc_html_e( 'branch only', 'hub2wp' ); ?>
+                                            <?php endif; ?>
+                                            <?php if ( ! empty( $repo_data['stylesheet'] ) ) : ?>
+                                                &rarr; <code><?php echo esc_html( $repo_data['stylesheet'] ); ?></code>
+                                            <?php endif; ?>
+                                        </small>
+                                    </td>
+                                    <td>
+                                        <?php
+                                        if ( ! empty( $repo_data['installed'] ) ) {
+                                            esc_html_e( 'Installed', 'hub2wp' );
+                                        } else {
+                                            esc_html_e( 'Not Installed', 'hub2wp' );
+                                        }
+                                        if ( ! empty( $repo_data['private'] ) ) {
+                                            echo ' <span class="dashicons dashicons-lock" title="' . esc_attr__( 'Private Repository', 'hub2wp' ) . '"></span>';
+                                        }
+                                        ?>
+                                    </td>
+                                    <td>
+                                        <button type="button"
+                                            class="button button-small button-link-delete h2wp-single-remove-theme-btn"
+                                            data-repo-key="<?php echo esc_attr( $repo_key ); ?>"
+                                            data-confirm="<?php echo esc_js( sprintf( __( 'Stop monitoring "%s"?', 'hub2wp' ), $repo_key ) ); ?>">
+                                            <?php esc_html_e( 'Remove', 'hub2wp' ); ?>
+                                        </button>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                </form>
+            <?php else : ?>
 				<p class="description">
 					<?php esc_html_e( 'No theme repositories added yet.', 'hub2wp' ); ?>
 				</p>
@@ -531,6 +554,43 @@ class H2WP_Settings {
 			var label   = document.getElementById( 'h2wp-toggle-monitored-themes-label' );
 			var icon    = btn ? btn.querySelector( '.dashicons' ) : null;
 			if ( ! btn || ! content ) { return; }
+			// Individual remove
+			document.querySelectorAll( '.h2wp-single-remove-theme-btn' ).forEach( function( btn ) {
+				btn.addEventListener( 'click', function() {
+					var repoKey    = this.getAttribute( 'data-repo-key' );
+					var confirmMsg = this.getAttribute( 'data-confirm' );
+					if ( ! confirm( confirmMsg ) ) { return; }
+					document.getElementById( 'h2wp-single-remove-theme-key' ).value = repoKey;
+					document.getElementById( 'h2wp-single-remove-theme-form' ).submit();
+				} );
+			} );
+
+			// Bulk remove select all
+			var selectAllThemes = document.getElementById( 'h2wp-select-all-monitored-themes' );
+			var bulkThemeBtn    = document.getElementById( 'h2wp-bulk-remove-theme-btn' );
+			var updateBulkThemeBtn = function() {
+				var checked = document.querySelectorAll( '.h2wp-monitored-theme-cb:checked' ).length;
+				if ( bulkThemeBtn ) { bulkThemeBtn.disabled = checked === 0; }
+			};
+			if ( selectAllThemes ) {
+				selectAllThemes.addEventListener( 'change', function() {
+					document.querySelectorAll( '.h2wp-monitored-theme-cb' ).forEach( function( cb ) {
+						cb.checked = selectAllThemes.checked;
+					} );
+					updateBulkThemeBtn();
+				} );
+			}
+			document.querySelectorAll( '.h2wp-monitored-theme-cb' ).forEach( function( cb ) {
+				cb.addEventListener( 'change', function() {
+					var total   = document.querySelectorAll( '.h2wp-monitored-theme-cb' ).length;
+					var checked = document.querySelectorAll( '.h2wp-monitored-theme-cb:checked' ).length;
+					if ( selectAllThemes ) {
+						selectAllThemes.checked       = checked === total;
+						selectAllThemes.indeterminate = checked > 0 && checked < total;
+					}
+					updateBulkThemeBtn();
+				} );
+			} );
 			btn.addEventListener( 'click', function( e ) {
 				e.preventDefault();
 				var isExpanded = this.getAttribute( 'aria-expanded' ) === 'true';
@@ -564,7 +624,8 @@ class H2WP_Settings {
 	 * @param string $subdirectory Subdirectory path for monorepo plugins (empty for single repos).
 	 * @return string|WP_Error     The stored repo key on success, WP_Error on failure.
 	 */
-	public static function add_repo_to_monitored( $owner, $repo, $branch = '', $prioritize = true, $subdirectory = '' ) {
+	public static function add_repo_to_monitored( $owner, $repo, $branch = '', $prioritize = true, $subdirectory = '', $repo_type = 'plugin' ) {
+    	$repo_type = in_array( $repo_type, array( 'plugin', 'theme' ), true ) ? $repo_type : 'plugin';
 		$owner        = strtolower( sanitize_text_field( trim( (string) $owner ) ) );
 		$repo         = strtolower( sanitize_text_field( trim( (string) $repo ) ) );
 		$subdirectory = trim( sanitize_text_field( (string) $subdirectory ), '/' );
@@ -586,9 +647,10 @@ class H2WP_Settings {
 			? $owner . '/' . $repo . '/' . basename( $subdirectory )
 			: $owner . '/' . $repo;
 
-		$monitored_plugins = get_option( 'h2wp_plugins', array() );
+		$option_name       = ( 'theme' === $repo_type ) ? 'h2wp_themes' : 'h2wp_plugins';
+        $monitored_plugins = get_option( $option_name, array() );
 
-		if ( isset( $monitored_plugins[ $repo_key ] ) ) {
+        if ( isset( $monitored_plugins[ $repo_key ] ) ) {
 			return new WP_Error(
 				'h2wp_repo_exists',
 				// Translators: %s is the repository key.
@@ -621,7 +683,7 @@ class H2WP_Settings {
 
 		$monitored_plugins[ $repo_key ] = $entry;
 
-		if ( ! update_option( 'h2wp_plugins', $monitored_plugins ) ) {
+        if ( ! update_option( $option_name, $monitored_plugins ) ) {
 			return new WP_Error( 'h2wp_add_failed', __( 'Failed to save repository. Please try again.', 'hub2wp' ) );
 		}
 
@@ -643,8 +705,10 @@ class H2WP_Settings {
             && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_remove_theme_repo_nonce'] ) ), 'h2wp_remove_private_theme_repo' );
         $bulk_remove_nonce_valid = isset( $_POST['h2wp_bulk_remove_nonce'] )
             && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_bulk_remove_nonce'] ) ), 'h2wp_bulk_remove_repos' );
+        $bulk_remove_theme_nonce_valid = isset( $_POST['h2wp_bulk_remove_theme_nonce'] )
+            && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_bulk_remove_theme_nonce'] ) ), 'h2wp_bulk_remove_theme_repos' );
 
-        if ( ! $add_nonce_valid && ! $remove_nonce_valid && ! $add_theme_nonce_valid && ! $remove_theme_nonce_valid && ! $bulk_remove_nonce_valid ) {
+        if ( ! $add_nonce_valid && ! $remove_nonce_valid && ! $add_theme_nonce_valid && ! $remove_theme_nonce_valid && ! $bulk_remove_nonce_valid && ! $bulk_remove_theme_nonce_valid ) {
             return;
         }
 
@@ -664,6 +728,8 @@ class H2WP_Settings {
             self::handle_remove_private_theme_repo();
         } elseif ( 'bulk_remove_repos' === $action ) {
             self::handle_bulk_remove_repos();
+        } elseif ( 'bulk_remove_theme_repos' === $action ) {
+            self::handle_bulk_remove_theme_repos();
         }
 	}
 
@@ -1031,6 +1097,47 @@ class H2WP_Settings {
 			sprintf(
 				// Translators: %d is the number of repositories removed.
 				_n( '%d repository removed from monitoring.', '%d repositories removed from monitoring.', $removed, 'hub2wp' ),
+				$removed
+			),
+			'success'
+		);
+	}
+
+	/**
+	 * Handle bulk removal of monitored theme repositories.
+	 */
+	private static function handle_bulk_remove_theme_repos() {
+		if ( ! isset( $_POST['h2wp_bulk_remove_theme_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['h2wp_bulk_remove_theme_nonce'] ) ), 'h2wp_bulk_remove_theme_repos' ) ) {
+			add_settings_error( 'h2wp_theme_repos', 'h2wp_nonce_error', __( 'Security check failed. Please try again.', 'hub2wp' ), 'error' );
+			return;
+		}
+		if ( ! current_user_can( 'manage_options' ) ) {
+			add_settings_error( 'h2wp_theme_repos', 'h2wp_permission_error', __( 'You do not have permission to remove repositories.', 'hub2wp' ), 'error' );
+			return;
+		}
+		if ( empty( $_POST['h2wp_repo_keys'] ) || ! is_array( $_POST['h2wp_repo_keys'] ) ) {
+			add_settings_error( 'h2wp_theme_repos', 'h2wp_no_selection', __( 'No repositories selected for removal.', 'hub2wp' ), 'warning' );
+			return;
+		}
+
+		$repo_keys        = array_map( 'sanitize_text_field', wp_unslash( $_POST['h2wp_repo_keys'] ) );
+		$monitored_themes = get_option( 'h2wp_themes', array() );
+		$removed          = 0;
+
+		foreach ( $repo_keys as $repo_key ) {
+			if ( isset( $monitored_themes[ $repo_key ] ) ) {
+				unset( $monitored_themes[ $repo_key ] );
+				$removed++;
+			}
+		}
+
+		update_option( 'h2wp_themes', $monitored_themes );
+
+		add_settings_error(
+			'h2wp_theme_repos',
+			'h2wp_bulk_theme_removed',
+			sprintf(
+				_n( '%d theme repository removed from monitoring.', '%d theme repositories removed from monitoring.', $removed, 'hub2wp' ),
 				$removed
 			),
 			'success'

--- a/includes/class-h2wp-settings.php
+++ b/includes/class-h2wp-settings.php
@@ -530,7 +530,7 @@ class H2WP_Settings {
                                     </td>
                                     <td>
                                         <button type="button"
-                                            class="button button-small h2wp-single-remove-btn"
+                                            class="button button-small h2wp-single-remove-theme-btn"
                                             data-repo-key="<?php echo esc_attr( $repo_key ); ?>"
                                             data-confirm="<?php echo esc_js( sprintf( __( 'Stop monitoring "%s"?', 'hub2wp' ), $repo_key ) ); ?>">
                                             <?php esc_html_e( 'Remove', 'hub2wp' ); ?>
@@ -658,28 +658,39 @@ class H2WP_Settings {
 			);
 		}
 
-		$plugin_file = false;
-		if ( class_exists( 'H2WP_Admin_Page' ) ) {
-			$plugin_file = H2WP_Admin_Page::get_installed_plugin_file( $owner, $repo );
-		}
+		// For monorepo entries the installed folder matches the slug, not the repo name
+        $lookup_slug = ! empty( $subdirectory ) ? basename( $subdirectory ) : $repo;
+        $plugin_file = false;
+        $stylesheet  = false;
 
-		$entry = array(
-			'owner'               => $owner,
-			'repo'                => $repo,
-			'name'                => ! empty( $subdirectory ) ? basename( $subdirectory ) : ( isset( $repo_data['name'] ) ? $repo_data['name'] : $repo ),
-			'private'             => isset( $repo_data['private'] ) ? (bool) $repo_data['private'] : false,
-			'branch'              => (string) $branch,
-			'prioritize_releases' => (bool) $prioritize,
-			'subdirectory'        => $subdirectory,
-			'added'               => time(),
-			'added_by'            => get_current_user_id(),
-			'last_checked'        => time(),
-			'last_updated'        => time(),
-		);
+        if ( class_exists( 'H2WP_Admin_Page' ) ) {
+            if ( 'theme' === $repo_type ) {
+                $stylesheet = H2WP_Admin_Page::get_installed_theme_stylesheet( $owner, $lookup_slug );
+            } else {
+                $plugin_file = H2WP_Admin_Page::get_installed_plugin_file( $owner, $lookup_slug );
+            }
+        }
 
-		if ( $plugin_file ) {
-			$entry['plugin_file'] = $plugin_file;
-		}
+        $entry = array(
+            'owner'               => $owner,
+            'repo'                => $repo,
+            'name'                => ! empty( $subdirectory ) ? basename( $subdirectory ) : ( isset( $repo_data['name'] ) ? $repo_data['name'] : $repo ),
+            'private'             => isset( $repo_data['private'] ) ? (bool) $repo_data['private'] : false,
+            'branch'              => (string) $branch,
+            'prioritize_releases' => (bool) $prioritize,
+            'subdirectory'        => $subdirectory,
+            'added'               => time(),
+            'added_by'            => get_current_user_id(),
+            'last_checked'        => time(),
+            'last_updated'        => time(),
+        );
+
+        if ( $plugin_file ) {
+            $entry['plugin_file'] = $plugin_file;
+        }
+        if ( $stylesheet ) {
+            $entry['stylesheet'] = $stylesheet;
+        }
 
 		$monitored_plugins[ $repo_key ] = $entry;
 

--- a/includes/class-h2wp-settings.php
+++ b/includes/class-h2wp-settings.php
@@ -161,7 +161,7 @@ class H2WP_Settings {
 		$monitored_plugins = $tracked_service->get_tracked_plugins();
 		$count             = count( $monitored_plugins );
 		// Auto-expand if there are form submission notices so feedback is visible.
-		$expanded          = ! empty( get_settings_errors( 'h2wp_private_repos' ) );
+		$expanded          = true;
 		?>
 		<p style="margin:0;">
 			<strong><?php esc_html_e( 'Monitored Plugins', 'hub2wp' ); ?></strong>
@@ -254,7 +254,7 @@ class H2WP_Settings {
                                 <input type="checkbox" id="h2wp-select-all-monitored" />
                             </th>
                             <th><?php esc_html_e( 'Repository', 'hub2wp' ); ?></th>
-                            <th style="width:80px;max-width:80px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
+                            <th style="width:100px;max-width:100px;"><?php esc_html_e( 'Status', 'hub2wp' ); ?></th>
                             <th style="width:80px;max-width:80px;"><?php esc_html_e( 'Actions', 'hub2wp' ); ?></th>
                         </tr>
                     </thead>
@@ -290,13 +290,13 @@ class H2WP_Settings {
 										esc_html_e( 'Not Installed', 'hub2wp' );
 									}
 									if ( ! empty( $repo_data['private'] ) ) {
-										echo ' <span class="dashicons dashicons-lock" title="' . esc_attr__( 'Private Repository', 'hub2wp' ) . '"></span>';
+										echo '<span class="dashicons dashicons-lock" title="' . esc_attr__( 'Private Repository', 'hub2wp' ) . '" style="font-size:14px;width:14px;height:16px;vertical-align:middle;margin-left:3px;"></span>';
 									}
 									?>
 								</td>
 								<td>
                                     <button type="button"
-                                        class="button button-small button-link-delete h2wp-single-remove-btn"
+                                        class="button button-small h2wp-single-remove-btn"
                                         data-repo-key="<?php echo esc_attr( $repo_key ); ?>"
                                         data-confirm="<?php echo esc_js( sprintf( __( 'Stop monitoring "%s"?', 'hub2wp' ), $repo_key ) ); ?>">
                                         <?php esc_html_e( 'Remove', 'hub2wp' ); ?>
@@ -395,7 +395,7 @@ class H2WP_Settings {
 		$tracked_service  = new H2WP_Tracked_Repo_Service();
 		$monitored_themes = $tracked_service->get_tracked_themes();
 		$count            = count( $monitored_themes );
-		$expanded         = ! empty( get_settings_errors( 'h2wp_theme_repos' ) );
+		$expanded         = true;
 		?>
 		<p style="margin:0;">
 			<strong><?php esc_html_e( 'Monitored Themes', 'hub2wp' ); ?></strong>
@@ -518,19 +518,19 @@ class H2WP_Settings {
                                     </td>
                                     <td>
                                         <?php
-                                        if ( ! empty( $repo_data['installed'] ) ) {
-                                            esc_html_e( 'Installed', 'hub2wp' );
-                                        } else {
-                                            esc_html_e( 'Not Installed', 'hub2wp' );
-                                        }
-                                        if ( ! empty( $repo_data['private'] ) ) {
-                                            echo ' <span class="dashicons dashicons-lock" title="' . esc_attr__( 'Private Repository', 'hub2wp' ) . '"></span>';
-                                        }
-                                        ?>
+										if ( ! empty( $repo_data['installed'] ) ) {
+											esc_html_e( 'Installed', 'hub2wp' );
+										} else {
+											esc_html_e( 'Not Installed', 'hub2wp' );
+										}
+										if ( ! empty( $repo_data['private'] ) ) {
+											echo '<span class="dashicons dashicons-lock" title="' . esc_attr__( 'Private Repository', 'hub2wp' ) . '" style="font-size:14px;width:14px;height:16px;vertical-align:middle;margin-left:3px;"></span>';
+										}
+										?>
                                     </td>
                                     <td>
                                         <button type="button"
-                                            class="button button-small button-link-delete h2wp-single-remove-theme-btn"
+                                            class="button button-small h2wp-single-remove-btn"
                                             data-repo-key="<?php echo esc_attr( $repo_key ); ?>"
                                             data-confirm="<?php echo esc_js( sprintf( __( 'Stop monitoring "%s"?', 'hub2wp' ), $repo_key ) ); ?>">
                                             <?php esc_html_e( 'Remove', 'hub2wp' ); ?>

--- a/includes/class-h2wp-settings.php
+++ b/includes/class-h2wp-settings.php
@@ -18,9 +18,10 @@ class H2WP_Settings {
 	 */
 	public static function init() {
 		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
-		add_action( 'admin_menu', array( __CLASS__, 'add_settings_page' ) );
-		add_action( 'admin_init', array( __CLASS__, 'handle_private_repo_actions' ) );
-		add_action( 'admin_init', array( __CLASS__, 'handle_run_update_check_action' ) );
+        add_action( 'admin_menu', array( __CLASS__, 'add_settings_page' ) );
+        add_action( 'admin_init', array( __CLASS__, 'handle_private_repo_actions' ) );
+        add_action( 'admin_init', array( __CLASS__, 'handle_run_update_check_action' ) );
+        add_action( 'admin_notices', array( __CLASS__, 'display_plugins_added_notice' ) );
 		add_action( 'admin_notices', array( __CLASS__, 'display_private_repo_notices' ) );
 		add_action( 'admin_post_h2wp_clear_cache', array( __CLASS__, 'handle_clear_cache' ) );
 		add_action( 'wp_ajax_h2wp_clear_cache', array( __CLASS__, 'ajax_clear_cache' ) );
@@ -492,6 +493,83 @@ class H2WP_Settings {
 	}
 
 	/**
+	 * Add a repository to the monitored plugins list.
+	 *
+	 * Shared by both the PHP form handler and the AJAX endpoint so the
+	 * logic lives in one place. Supports monorepo plugins via $subdirectory.
+	 *
+	 * @param string $owner        Repository owner.
+	 * @param string $repo         Repository name.
+	 * @param string $branch       Optional branch.
+	 * @param bool   $prioritize   Whether to prioritize releases.
+	 * @param string $subdirectory Subdirectory path for monorepo plugins (empty for single repos).
+	 * @return string|WP_Error     The stored repo key on success, WP_Error on failure.
+	 */
+	public static function add_repo_to_monitored( $owner, $repo, $branch = '', $prioritize = true, $subdirectory = '' ) {
+		$owner        = strtolower( sanitize_text_field( trim( (string) $owner ) ) );
+		$repo         = strtolower( sanitize_text_field( trim( (string) $repo ) ) );
+		$subdirectory = trim( sanitize_text_field( (string) $subdirectory ), '/' );
+
+		if ( empty( $owner ) || empty( $repo ) ) {
+			return new WP_Error( 'h2wp_invalid_repo', __( 'Invalid repository owner or name.', 'hub2wp' ) );
+		}
+
+		$access_token  = self::get_access_token();
+		$repo_key_base = $owner . '/' . $repo;
+
+		$repo_data = self::verify_repo( $repo_key_base, $access_token );
+		if ( is_wp_error( $repo_data ) ) {
+			return $repo_data;
+		}
+
+		// Monorepo plugins get owner/repo/slug as their key to avoid collisions
+		$repo_key = ! empty( $subdirectory )
+			? $owner . '/' . $repo . '/' . basename( $subdirectory )
+			: $owner . '/' . $repo;
+
+		$monitored_plugins = get_option( 'h2wp_plugins', array() );
+
+		if ( isset( $monitored_plugins[ $repo_key ] ) ) {
+			return new WP_Error(
+				'h2wp_repo_exists',
+				// Translators: %s is the repository key.
+				sprintf( __( 'Repository "%s" is already in your monitored plugins list.', 'hub2wp' ), $repo_key )
+			);
+		}
+
+		$plugin_file = false;
+		if ( class_exists( 'H2WP_Admin_Page' ) ) {
+			$plugin_file = H2WP_Admin_Page::get_installed_plugin_file( $owner, $repo );
+		}
+
+		$entry = array(
+			'owner'               => $owner,
+			'repo'                => $repo,
+			'name'                => ! empty( $subdirectory ) ? basename( $subdirectory ) : ( isset( $repo_data['name'] ) ? $repo_data['name'] : $repo ),
+			'private'             => isset( $repo_data['private'] ) ? (bool) $repo_data['private'] : false,
+			'branch'              => (string) $branch,
+			'prioritize_releases' => (bool) $prioritize,
+			'subdirectory'        => $subdirectory,
+			'added'               => time(),
+			'added_by'            => get_current_user_id(),
+			'last_checked'        => time(),
+			'last_updated'        => time(),
+		);
+
+		if ( $plugin_file ) {
+			$entry['plugin_file'] = $plugin_file;
+		}
+
+		$monitored_plugins[ $repo_key ] = $entry;
+
+		if ( ! update_option( 'h2wp_plugins', $monitored_plugins ) ) {
+			return new WP_Error( 'h2wp_add_failed', __( 'Failed to save repository. Please try again.', 'hub2wp' ) );
+		}
+
+		return $repo_key;
+	}
+
+	/**
 	 * Handle private repository actions (add/remove).
 	 */
 	public static function handle_private_repo_actions() {
@@ -923,6 +1001,31 @@ class H2WP_Settings {
 		// displays settings errors on options pages. Calling it manually would cause
 		// duplicate notices. The add_settings_error() calls in handle_private_repo_actions()
 		// are sufficient for notices to appear.
+	}
+
+	/**
+	 * Display a success notice after monorepo plugins are added via AJAX redirect.
+	 */
+	public static function display_plugins_added_notice() {
+		if ( ! isset( $_GET['page'] ) || 'h2wp_settings_page' !== sanitize_key( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		if ( empty( $_GET['h2wp_added'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		$count = absint( $_GET['h2wp_added'] );
+		if ( ! $count ) {
+			return;
+		}
+		echo '<div class="notice notice-success is-dismissible"><p>';
+		echo esc_html(
+			sprintf(
+				// Translators: %d is the number of plugins added.
+				_n( '%d plugin added to monitoring successfully.', '%d plugins added to monitoring successfully.', $count, 'hub2wp' ),
+				$count
+			)
+		);
+		echo '</p></div>';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pbalazs
 Tags: github, plugins, installer
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.6.0
+Stable tag: 1.6.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -60,6 +60,12 @@ Manage hub2wp settings with WP-CLI too:
 No, but you have a higher request limit if you use one.
 
 == Changelog ==
+
+= 1.6.1 = 
+* Better sub-menu position for 'Add Github Plugin'
+* Added sub-menu item for 'Add GitHub Theme' under 'Appearance
+* Added 'Add GitHub Plugin' button next to the 'Add Plugin' button on /wp-admin/plugins.php
+* Changed 'GitHub themes' button next to the 'Add Theme' button to 'Add GitHub Theme' on /wp-admin/themes.php
 
 = 1.6.0 =
 * Mono-repo support added

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: pbalazs
 Tags: github, plugins, installer
 Requires at least: 5.8
 Tested up to: 7.0
-Stable tag: 1.5.2
+Stable tag: 1.6.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -60,6 +60,15 @@ Manage hub2wp settings with WP-CLI too:
 No, but you have a higher request limit if you use one.
 
 == Changelog ==
+
+= 1.6.0 =
+* Mono-repo support added
+* Animate loading actions and show selected plugins count
+* "Already Monitoring" in 'Add Repository' picker
+* Bulk remove options added to Monitored Plugins table
+* Theme support for monorepo themes
+* Better padlock formatting and expand theme repo by default
+* Fixed a bunch of issues around plugin/theme tracking
 
 = 1.5.2 =
 * Added list of known-incompatible plugins and themes, to exclude them from search results.


### PR DESCRIPTION
### Summary

This PR of hub2wp supports monorepos for plugins and themes, along with single dedicated plugin/theme repos.

It also includes a bunch of small bug fixes and UI updates I noticed as I was testing the plugin.

### Changes

- Added support for monorepos containing multiple plugins and/or themes.
- Maintained support for existing single-plugin and single-theme repository workflows.
- Fixed a bunch of misc small bugs discovered during testing, also:
  - Fixed system tracking of installed plugins and themes (to prevent duplicate installations)
- Made a number of small UI/UX improvements and usability updates:
  - Animate loading actions
  - Show selected plugins count
  - "Already monitoring" added to 'Add Repository' picker
  - Ability to let the user bulk remove options added to the 'Monitored Plugins' table
  - Better padlock formatting and alignment
  - Theme repo section now expands/displays by default (follows same behaviour as plugin section)
  - Added consistent, native-looking integration of hub2wp plugins and themes into wp-admin areas (plugins.php, themes.php)

### Notes

The existing workflow should continue to work as before for users with dedicated plugin/theme repositories. The new functionality allows repositories containing multiple plugins or themes to be configured and deployed correctly.